### PR TITLE
Bugfix - annotation missing on first chart generation

### DIFF
--- a/bikespace_dashboard/js/components/sidebar/duration_tod_chart.js
+++ b/bikespace_dashboard/js/components/sidebar/duration_tod_chart.js
@@ -124,6 +124,8 @@ class DurationTimeOfDayChart extends Component {
     // generate plot on page
     Plotly.newPlot(this.plot, chart_data, layout, config);
 
+    // add label to max value
+    this.addMaxLabel();
 
   }
 


### PR DESCRIPTION
Ensure annotation gets added on first chart draw for duration vs time of day chart