### PR TITLE
BUGFIX - fixing overlap of nav links with main app start button

### DIFF
--- a/bikespace_dashboard/css/components/page.css
+++ b/bikespace_dashboard/css/components/page.css
@@ -46,6 +46,7 @@ header {
                     vertical-align: middle;
                     text-decoration: none;
                     padding: 0.2rem 0.4rem;
+                    color: var(--color-secondary-dark-grey);
 
                     &:visited {
                         color: var(--color-secondary-dark-grey);

--- a/bikespace_frontend/src/styles/global.scss
+++ b/bikespace_frontend/src/styles/global.scss
@@ -22,7 +22,7 @@ nav {
   left: 0;
   bottom: 0;
   width: 100%;
-  padding-bottom: 1.8rem;
+  padding-bottom: 1rem;
   ul {
     display: flex;
     flex-flow: row wrap;

--- a/bikespace_frontend/src/styles/index.css.ts
+++ b/bikespace_frontend/src/styles/index.css.ts
@@ -13,7 +13,12 @@ export const main = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  height: '100vh',
+  position: 'absolute',
+  bottom: 0,
+  top: 0,
+  left: 0,
+  right: 0,
+  // height: '100vh',
 });
 
 export const mainContent = style({


### PR DESCRIPTION
Nav links were overlapping with the start submission button on iOS due to issues with how Safari on iOS calculates vh units

## Before

<img src="https://github.com/bikespace/bikespace/assets/8128933/0db85137-f85a-48b3-b660-4548389f67b7" width="250px"></img>

## After

<img src="https://github.com/bikespace/bikespace/assets/8128933/f8104b6b-859b-4a9a-af03-6b53f3370f3f" width="250px"></img>