### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,25 @@ They are split up accordingly into their own directories:
 
 To run any of these components please see the `README` in each directory.
 
-This repository also has a `bikespace_landing_page` folder for the [bikespace.ca](https://bikespace.ca/) content.
+This repository also has a `bikespace_landing_page` folder for the [bikespace.ca](https://bikespace.ca/) content and a `datasets` folder for miscellaneous project data.
 
 # Development Workflow
 
-- When working on a new feature, please always check out a new branch from the latest main branch
-- When submitting Pull Requests, please submit PRs to the development branch from the feature branch you are working off
-- Squash and merge is preferred for approved pull requests to keep a clean history of project changes
+- When working on a new feature, please always check out a new branch from the latest main branch.
+- When submitting Pull Requests, please submit PRs to the development branch from the feature branch you are working off of.
+- Squash and merge is preferred for approved pull requests to keep a clean history of project changes.
 
 For more information about contributing to the BikeSpace project, please read the [Get Involved](https://bikespace.ca/#get_involved) section of our website.
+
+# Using Make Targets
+
+Most development tasks in this repository (e.g. running apps, linting code) can be run using [`make`](https://en.wikipedia.org/wiki/Make_(software)) targets that simplify multiple steps into one command and work cross-platform. For example, to run `bikespace_frontend` locally while developing, you can run the following in a terminal:
+
+```bash
+$ make run-frontend
+```
+
+Note that you may need to ensure that there are no spaces in the filepath for the project directory for the `make` command to work as intended.
 
 # Project Structure
 

--- a/bikespace_api/README.md
+++ b/bikespace_api/README.md
@@ -5,19 +5,18 @@ The API service is a python Flask application paired with a Postgres database.
 
 To develop the API locally you'll require the following things:
  - Python version 3.9.6 or greater
- - Postgres database running on port 5432, version 15 or greater
+ - Postgres database running on the default port 5432, version 15 or greater
 
 ## Database
 
-To successfully run the api locally we require a Postgres database running along side the Flask application.
-Ensure that Postgres is running in port `5432` with an empty database `bikespace_dev` with default credentials of `postgres:postgres`
+To successfully run the API locally we require a Postgres database running along side the Flask application. You will have to install Postgres on your system and run the set-up steps noted below. Once set up, ensure that Postgres is running in port `5432` with an empty database `bikespace_dev` with default credentials of `postgres:postgres` (i.e. username and password are both `postgres`).
 
 ## Running the API service
 
 There are various make targets to help run/build tasks.
 Running the backend service:
 ```shell 
-make run-flask-app
+$ make run-flask-app
 ```
 The development server should now to be running at `127.0.0.1:8000`
 
@@ -26,3 +25,41 @@ The development server should now to be running at `127.0.0.1:8000`
 The api follows an OpenAPI 3.0 Spec, the spec can be found at `bikespace_api/bikespace_api/static/bikespace-open-api.yaml`
 
 The swagger-ui to render the OpenAPI spec can be found at `127.0.0.1:8000/api/v2/docs`
+
+## Database Set-Up
+
+These instructions are for setting up the database for use in local development.
+
+### Install Postgres
+
+Download the version of Postgres that matches your system using the links on [postgresql.org](https://www.postgresql.org/).
+
+You should be able to use the default installation options in your installer package:
+
+- When the installer prompts you for the password for the database superuser (`postgres`), enter `postgres`.
+- Leave the default port as `5432`.
+- You don't need to run stack builder after installation.
+
+### Create and set up the bikespace_dev database
+
+These instructions are for the default pgAdmin app, but you may find other apps like [Postico](https://eggerapps.at/postico2/) easier to use.
+
+In pgAdmin:
+
+- Open the Servers list on the left and enter the password (`postgres`).
+- Right-click on Databases, then select Create > Database...
+- Database name should be `bikespace_dev`; select Save to create.
+
+In a terminal (in the root folder of the repo):
+
+- run `$ make recreate-db` to create the table(s) used by the API.
+- run `$ make seed-db` to enter dummy data to be used during development.
+
+To see the results of these actions in pgAdmin, right-click the `bikespace_dev` database and select Refresh. The database tables are under Schemas. You can right-click a table and select View/Edit Data to see the entries.
+
+To test the API is working with the database:
+
+- In a terminal, run `$ make run-flask-app` and navigate to the local url it runs on (usually http://127.0.0.1:8000) to open the Swagger UI page.
+- On the Swagger page, you can open GET and select "Try it out" - if everything is working correctly, the API should return the dummy data.
+- If you run the frontend application (`$ make run-frontend` in a separate terminal) and use it to make a new submission, you should be able to see it by making another GET request to the API or re-executing the table view in pgAdmin.
+

--- a/bikespace_api/bikespace_api/static/bikespace-open-api.yaml
+++ b/bikespace_api/bikespace_api/static/bikespace-open-api.yaml
@@ -5,7 +5,7 @@ info:
   description: BikeSpace API
 
 servers:
-  - url: http://127.0.0.1/api/v2
+  - url: /api/v2
   - url: https://api-dev.bikespace.ca/api/v2
 
 paths:


### PR DESCRIPTION
Added some edits and additions to the README files to make it easier to get set up with running the API.

Also addressed two issues I ran into in the past:

- Make does not work as intended if filepath has spaces - added a note about this in the root folder README (as well as some general info about how to use the Make targets)
- Swagger UI did not work in local development - issue was that the local url did not include the port number; changed it to a relative url so that it will work regardless of port number used