### PR TITLE
Add lazy loading wrapper for plotly's Plot component with react-loadable

### DIFF
--- a/bikespace_frontend/package-lock.json
+++ b/bikespace_frontend/package-lock.json
@@ -32,6 +32,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-leaflet": "^4.2.1",
+        "react-loadable": "^5.5.0",
         "react-plotly.js": "^2.6.0"
       },
       "devDependencies": {
@@ -48,6 +49,7 @@
         "@types/plotly.js-dist-min": "^2.3.4",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
+        "@types/react-loadable": "^5.5.11",
         "@types/react-plotly.js": "^2.6.3",
         "@typescript-eslint/eslint-plugin": "^6.18.0",
         "babel-jest": "^29.7.0",
@@ -5892,6 +5894,16 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-loadable": {
+      "version": "5.5.11",
+      "resolved": "https://registry.npmjs.org/@types/react-loadable/-/react-loadable-5.5.11.tgz",
+      "integrity": "sha512-/tq2IJ853MoIFRBmqVOxnGsRRjER5TmEKzsZtaAkiXAWoDeKgR/QNOT1vd9k0p9h/F616X21cpNh3hu4RutzRQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*",
+        "@types/webpack": "^4"
+      }
+    },
     "node_modules/@types/react-plotly.js": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/@types/react-plotly.js/-/react-plotly.js-2.6.3.tgz",
@@ -5937,11 +5949,23 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
       "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw=="
     },
+    "node_modules/@types/source-list-map": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.6.tgz",
+      "integrity": "sha512-5JcVt1u5HDmlXkwOD2nslZVllBBc7HDuOICfiZah2Z0is8M8g+ddAEawbmd3VjedfDHBzxCaXLs07QEmb7y54g==",
+      "devOptional": true
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
+    },
+    "node_modules/@types/tapable": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.12.tgz",
+      "integrity": "sha512-bTHG8fcxEqv1M9+TD14P8ok8hjxoOCkfKc8XXLaaD05kI7ohpeI956jtDOD3XHKBQrlyPughUtzm1jtVhHpA5Q==",
+      "devOptional": true
     },
     "node_modules/@types/tmp": {
       "version": "0.0.33",
@@ -5953,6 +5977,58 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
+    },
+    "node_modules/@types/uglify-js": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.17.5.tgz",
+      "integrity": "sha512-TU+fZFBTBcXj/GpDpDaBmgWk/gn96kMZ+uocaFUlV2f8a6WdMzzI44QBCmGcCiYR0Y6ZlNRiyUyKKt5nl/lbzQ==",
+      "devOptional": true,
+      "dependencies": {
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/@types/uglify-js/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@types/webpack": {
+      "version": "4.41.38",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.38.tgz",
+      "integrity": "sha512-oOW7E931XJU1mVfCnxCVgv8GLFL768pDO5u2Gzk82i8yTIgX6i7cntyZOkZYb/JtYM8252SN9bQp9tgkVDSsRw==",
+      "devOptional": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tapable": "^1",
+        "@types/uglify-js": "*",
+        "@types/webpack-sources": "*",
+        "anymatch": "^3.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/@types/webpack-sources": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-4nZOdMwSPHZ4pTEZzSp0AsTM4K7Qmu40UKW4tJDiOVs20UzYF9l+qUe4s0ftfN0pin06n+5cWWDJXH+sbhAiDw==",
+      "devOptional": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/source-list-map": "*",
+        "source-map": "^0.7.3"
+      }
+    },
+    "node_modules/@types/webpack/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -20033,6 +20109,17 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/react-loadable": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-loadable/-/react-loadable-5.5.0.tgz",
+      "integrity": "sha512-C8Aui0ZpMd4KokxRdVAm2bQtI03k2RMRNzOB+IipV3yxFTSVICv7WoUr5L9ALB5BmKO1iHgZtWM8EvYG83otdg==",
+      "dependencies": {
+        "prop-types": "^15.5.0"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-plotly.js": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/react-plotly.js/-/react-plotly.js-2.6.0.tgz",
@@ -28356,6 +28443,16 @@
         "@types/react": "*"
       }
     },
+    "@types/react-loadable": {
+      "version": "5.5.11",
+      "resolved": "https://registry.npmjs.org/@types/react-loadable/-/react-loadable-5.5.11.tgz",
+      "integrity": "sha512-/tq2IJ853MoIFRBmqVOxnGsRRjER5TmEKzsZtaAkiXAWoDeKgR/QNOT1vd9k0p9h/F616X21cpNh3hu4RutzRQ==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "@types/webpack": "^4"
+      }
+    },
     "@types/react-plotly.js": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/@types/react-plotly.js/-/react-plotly.js-2.6.3.tgz",
@@ -28401,11 +28498,23 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
       "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw=="
     },
+    "@types/source-list-map": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.6.tgz",
+      "integrity": "sha512-5JcVt1u5HDmlXkwOD2nslZVllBBc7HDuOICfiZah2Z0is8M8g+ddAEawbmd3VjedfDHBzxCaXLs07QEmb7y54g==",
+      "devOptional": true
+    },
     "@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
+    },
+    "@types/tapable": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.12.tgz",
+      "integrity": "sha512-bTHG8fcxEqv1M9+TD14P8ok8hjxoOCkfKc8XXLaaD05kI7ohpeI956jtDOD3XHKBQrlyPughUtzm1jtVhHpA5Q==",
+      "devOptional": true
     },
     "@types/tmp": {
       "version": "0.0.33",
@@ -28417,6 +28526,56 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
+    },
+    "@types/uglify-js": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.17.5.tgz",
+      "integrity": "sha512-TU+fZFBTBcXj/GpDpDaBmgWk/gn96kMZ+uocaFUlV2f8a6WdMzzI44QBCmGcCiYR0Y6ZlNRiyUyKKt5nl/lbzQ==",
+      "devOptional": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "devOptional": true
+        }
+      }
+    },
+    "@types/webpack": {
+      "version": "4.41.38",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.38.tgz",
+      "integrity": "sha512-oOW7E931XJU1mVfCnxCVgv8GLFL768pDO5u2Gzk82i8yTIgX6i7cntyZOkZYb/JtYM8252SN9bQp9tgkVDSsRw==",
+      "devOptional": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/tapable": "^1",
+        "@types/uglify-js": "*",
+        "@types/webpack-sources": "*",
+        "anymatch": "^3.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "devOptional": true
+        }
+      }
+    },
+    "@types/webpack-sources": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-4nZOdMwSPHZ4pTEZzSp0AsTM4K7Qmu40UKW4tJDiOVs20UzYF9l+qUe4s0ftfN0pin06n+5cWWDJXH+sbhAiDw==",
+      "devOptional": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/source-list-map": "*",
+        "source-map": "^0.7.3"
+      }
     },
     "@types/yargs": {
       "version": "17.0.32",
@@ -38919,6 +39078,14 @@
       "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
       "requires": {
         "@react-leaflet/core": "^2.1.0"
+      }
+    },
+    "react-loadable": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-loadable/-/react-loadable-5.5.0.tgz",
+      "integrity": "sha512-C8Aui0ZpMd4KokxRdVAm2bQtI03k2RMRNzOB+IipV3yxFTSVICv7WoUr5L9ALB5BmKO1iHgZtWM8EvYG83otdg==",
+      "requires": {
+        "prop-types": "^15.5.0"
       }
     },
     "react-plotly.js": {

--- a/bikespace_frontend/package.json
+++ b/bikespace_frontend/package.json
@@ -50,6 +50,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.2.1",
+    "react-loadable": "^5.5.0",
     "react-plotly.js": "^2.6.0"
   },
   "devDependencies": {
@@ -66,6 +67,7 @@
     "@types/plotly.js-dist-min": "^2.3.4",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
+    "@types/react-loadable": "^5.5.11",
     "@types/react-plotly.js": "^2.6.3",
     "@typescript-eslint/eslint-plugin": "^6.18.0",
     "babel-jest": "^29.7.0",

--- a/bikespace_frontend/src/components/dashboard/data-duration-by-tod-chart/DataDurationByTodChart.tsx
+++ b/bikespace_frontend/src/components/dashboard/data-duration-by-tod-chart/DataDurationByTodChart.tsx
@@ -9,6 +9,8 @@ import {ParkingDuration} from '@/interfaces/Submission';
 
 import {SubmissionsContext} from '../context';
 
+import {LazyPlot} from '../lazy-plot';
+
 import * as styles from './data-duration-by-tod-chart.module.scss';
 
 export function DataDurationByTodChart({
@@ -51,7 +53,7 @@ export function DataDurationByTodChart({
   }, [data]);
 
   return (
-    <Plot
+    <LazyPlot
       className={className}
       data={[
         {

--- a/bikespace_frontend/src/components/dashboard/data-frequency-by-day-chart/DataFrequencyByDayChart.tsx
+++ b/bikespace_frontend/src/components/dashboard/data-frequency-by-day-chart/DataFrequencyByDayChart.tsx
@@ -8,6 +8,8 @@ import {Day} from '@/interfaces/Submission';
 
 import {SubmissionFiltersContext, SubmissionsContext} from '../context';
 
+import {LazyPlot} from '../lazy-plot';
+
 import * as styles from './data-frequency-by-day-chart.module.scss';
 
 type InputData = {
@@ -53,7 +55,7 @@ export function DataFrequencyByDayChart({
   };
 
   return (
-    <Plot
+    <LazyPlot
       className={className}
       data={[
         {

--- a/bikespace_frontend/src/components/dashboard/data-issue-frequency-chart/DataIssueFrequencyChart.tsx
+++ b/bikespace_frontend/src/components/dashboard/data-issue-frequency-chart/DataIssueFrequencyChart.tsx
@@ -8,6 +8,8 @@ import {IssueType} from '@/interfaces/Submission';
 
 import {SubmissionFiltersContext, SubmissionsContext} from '../context';
 
+import {LazyPlot} from '../lazy-plot';
+
 import * as styles from './data-issue-frequency-chart.module.scss';
 
 type InputData = {
@@ -54,7 +56,7 @@ export function DataIssueFrequencyChart({
   };
 
   return (
-    <Plot
+    <LazyPlot
       className={className}
       data={[
         {

--- a/bikespace_frontend/src/components/dashboard/lazy-plot/LazyPlot.tsx
+++ b/bikespace_frontend/src/components/dashboard/lazy-plot/LazyPlot.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Loadable from 'react-loadable';
+import {PlotParams} from 'react-plotly.js';
+
+// Make Plotly plot lazy-loadable - only executed when browser APIs are available on client
+const Plotly = Loadable({
+  loader: () => import('react-plotly.js'),
+  loading: ({timedOut}) =>
+    timedOut ? <blockquote>Error: Loading Plotly timed out.</blockquote> : null,
+  timeout: 10000,
+});
+
+export const LazyPlot = (props: PlotParams) => {
+  return <Plotly {...props} />;
+};

--- a/bikespace_frontend/src/components/dashboard/lazy-plot/index.ts
+++ b/bikespace_frontend/src/components/dashboard/lazy-plot/index.ts
@@ -1,0 +1,1 @@
+export {LazyPlot} from './LazyPlot';


### PR DESCRIPTION
I found [janosh's solution](https://janosh.dev/posts/gatsby-interactive-plots) and implemented a `LazyPlot` lazy-loading component wrapper for `plotly`'s `Plot` with `react-loadable`. Build step (`make build-frontend`) seems to be passing now.

Plots still work as intended on development as well.