### PR TITLE
#168 fix: Leaflet locate control should cancel following when an issue is selected in the sidebar

### DIFF
--- a/bikespace_frontend/src/components/dashboard/map-handler/MapHandler.tsx
+++ b/bikespace_frontend/src/components/dashboard/map-handler/MapHandler.tsx
@@ -22,7 +22,11 @@ export const MapHandler = () => {
       .locate()
       .on('locationfound', e => {
         trackUmamiEvent('locationfound');
+
         map.flyTo(e.latlng, map.getZoom());
+
+        // Stop location tracking after location found
+        map.stopLocate();
       })
       .on('locationerror', err => {
         const code = err.code as 0 | 1 | 2 | 3;


### PR DESCRIPTION
Possible fix for issue [#168](https://github.com/bikespace/bikespace/issues/168) - added a line in `<MapHandler />` to stop tracking user location changes once the user location is found, via `map.stopLocate()`.