### PR TITLE
Fix fly.io release scripts that upgrade and migrates database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,12 @@ migrate-db:
 upgrade-db:
 	$(PYTHON) $(MANAGE_PY) db upgrade --directory $(BIKESPACE_DB_MIGRATIONS)
 
+db-history:
+	$(PYTHON) $(MANAGE_PY) db history --directory $(BIKESPACE_DB_MIGRATIONS)
+
+db-merge-heads:
+	$(PYTHON) $(MANAGE_PY) db merge heads -m "Merge heads" --directory $(BIKESPACE_DB_MIGRATIONS)
+
 db-stamp-heads:
 	$(PYTHON) $(MANAGE_PY) db stamp heads --directory $(BIKESPACE_DB_MIGRATIONS)
 

--- a/bikespace_api/fly.toml
+++ b/bikespace_api/fly.toml
@@ -11,7 +11,7 @@ processes = []
   buildpacks = ["paketo-buildpacks/python"]
 
 [build.args]
-  BP_CPYTHON_VERSION = "3.12.2"
+  BP_CPYTHON_VERSION = "3.12.4"
 
 [env]
   PORT = "8000"

--- a/bikespace_api/fly_release.sh
+++ b/bikespace_api/fly_release.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 
+python manage.py db stamp heads --directory migrations
 python manage.py db upgrade --directory migrations
 python manage.py db migrate --directory migrations

--- a/bikespace_api/migrations/versions/2e08b93c5a80_merge_heads.py
+++ b/bikespace_api/migrations/versions/2e08b93c5a80_merge_heads.py
@@ -1,0 +1,24 @@
+"""Merge heads
+
+Revision ID: 2e08b93c5a80
+Revises: 15b48eae3261, d950b6fcba82
+Create Date: 2024-08-10 08:35:38.257658
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2e08b93c5a80'
+down_revision = ('15b48eae3261', 'd950b6fcba82')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
- Fix diverged alembic heads that were failing to allow database upgrades
- Bumped python version for fly to 3.12.4
- Added make targets for various alembic commands