### PR TITLE
Date fix for current dashboard

### DIFF
--- a/bikespace_dashboard/.eslintrc.js
+++ b/bikespace_dashboard/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
   plugins: baseConfig.plugins.filter(notNode),
   parserOptions: {
     sourceType: 'module',
-    ecmaVersion: 2020,
+    ecmaVersion: 'latest',
   },
   globals: {
     ...baseConfig.globals,

--- a/bikespace_dashboard/js/components/api_tools.js
+++ b/bikespace_dashboard/js/components/api_tools.js
@@ -1,6 +1,18 @@
+import {DateTime} from '../../libraries/luxon.min.js';
 import {cssVarHSL} from './sidebar/data-panel/plot_utils.js';
 
-const parking_time_date_format = 'EEE, dd MMM yyyy hh:mm:ss z';
+const parking_time_date_format = 'yyyy-MM-dd hh:mm:ss';
+
+/**
+ * Parses parking_time string from API and returns Luxon DateTime
+ * @param {string} dateString 
+ * @returns {DateTime}
+ */
+function parseParkingTime(dateString) {
+  const msRemoved = dateString.split(".")[0];
+  const dtParsed = DateTime.fromFormat(msRemoved, parking_time_date_format, {zone: 'UTC'},);
+  return dtParsed.setZone("America/Toronto");
+}
 
 // for "render_priority", 0 is the highest priority and higher numbers are lower priority
 const issue_attributes = {
@@ -87,6 +99,6 @@ const parking_duration_attributes = {
 export {
   issue_attributes,
   issueIdToLabel,
-  parking_time_date_format,
+  parseParkingTime,
   parking_duration_attributes,
 };

--- a/bikespace_dashboard/js/components/api_tools.js
+++ b/bikespace_dashboard/js/components/api_tools.js
@@ -5,13 +5,15 @@ const parking_time_date_format = 'yyyy-MM-dd hh:mm:ss';
 
 /**
  * Parses parking_time string from API and returns Luxon DateTime
- * @param {string} dateString 
+ * @param {string} dateString
  * @returns {DateTime}
  */
 function parseParkingTime(dateString) {
-  const msRemoved = dateString.split(".")[0];
-  const dtParsed = DateTime.fromFormat(msRemoved, parking_time_date_format, {zone: 'UTC'},);
-  return dtParsed.setZone("America/Toronto");
+  const msRemoved = dateString.split('.')[0];
+  const dtParsed = DateTime.fromFormat(msRemoved, parking_time_date_format, {
+    zone: 'UTC',
+  });
+  return dtParsed.setZone('America/Toronto');
 }
 
 // for "render_priority", 0 is the highest priority and higher numbers are lower priority

--- a/bikespace_dashboard/js/components/hash_router.js
+++ b/bikespace_dashboard/js/components/hash_router.js
@@ -29,7 +29,7 @@ class HashRouter {
       );
     }
 
-    window.addEventListener('hashchange', (e) => {
+    window.addEventListener('hashchange', e => {
       this.refreshCurrent();
       this.executeCallbacks();
     });

--- a/bikespace_dashboard/js/components/main.js
+++ b/bikespace_dashboard/js/components/main.js
@@ -1,5 +1,5 @@
 import {DateTime} from '../../libraries/luxon.min.js';
-import {parking_time_date_format} from '../components/api_tools.js';
+import {parseParkingTime} from '../components/api_tools.js';
 
 const elementIdToComponentKey = id => id.replace('-', '_');
 
@@ -216,11 +216,7 @@ class DateRangeFilter extends ReportFilter {
   }
 
   test(report) {
-    const dt = DateTime.fromFormat(
-      report.parking_time,
-      parking_time_date_format,
-      {zone: 'America/Toronto'}
-    );
+    const dt = parseParkingTime(report.parking_time);
     for (const interval of this._state) {
       if (interval.contains(dt)) return true;
     }
@@ -251,11 +247,7 @@ class WeekDayPeriodFilter extends ReportFilter {
 
   test(report) {
     // Fri, 05 Jan 2024 09:22:06 GMT
-    const dt = DateTime.fromFormat(
-      report.parking_time,
-      parking_time_date_format,
-      {zone: 'America/Toronto'}
-    );
+    const dt = parseParkingTime(report.parking_time);
     const inclWeekdays = this._state.map(x => this.#dayIndex[x]);
     return inclWeekdays.includes(dt.weekday);
   }

--- a/bikespace_dashboard/js/components/map.js
+++ b/bikespace_dashboard/js/components/map.js
@@ -212,7 +212,7 @@ class Map extends Component {
       const issues = point.issues
         .map(x => issue_tags[x] ?? `<div class="issue">${x}</div>`)
         .join(' ');
-      const parking_time = new Date(point.parking_time);
+      const parking_time = new Date(point.parking_time + "+00:00");
       const parking_time_desc = parking_time.toLocaleString('en-CA', {
         dateStyle: 'full',
         timeStyle: 'short',

--- a/bikespace_dashboard/js/components/map.js
+++ b/bikespace_dashboard/js/components/map.js
@@ -212,7 +212,7 @@ class Map extends Component {
       const issues = point.issues
         .map(x => issue_tags[x] ?? `<div class="issue">${x}</div>`)
         .join(' ');
-      const parking_time = new Date(point.parking_time + "+00:00");
+      const parking_time = new Date(point.parking_time + '+00:00');
       const parking_time_desc = parking_time.toLocaleString('en-CA', {
         dateStyle: 'full',
         timeStyle: 'short',

--- a/bikespace_dashboard/js/components/sidebar/data-panel/day_chart.js
+++ b/bikespace_dashboard/js/components/sidebar/data-panel/day_chart.js
@@ -1,7 +1,7 @@
 import {Component, WeekDayPeriodFilter} from '../../main.js';
 import {defaults, cssVarHSL} from './plot_utils.js';
 import {DateTime} from '../../../../libraries/luxon.min.js';
-import {parking_time_date_format} from '../../api_tools.js';
+import {parseParkingTime} from '../../api_tools.js';
 
 class DayChart extends Component {
   /**
@@ -129,11 +129,7 @@ class DayChart extends Component {
     this.inputData = this.inputData.map(r =>
       Object.assign(r, {
         count: display_data_all_days.reduce((a, b) => {
-          const bdt = DateTime.fromFormat(
-            b.parking_time,
-            parking_time_date_format,
-            {zone: 'America/Toronto'}
-          );
+          const bdt = parseParkingTime(b.parking_time);
           return a + (bdt.weekday === r.index ? 1 : 0);
         }, 0),
       })

--- a/bikespace_dashboard/js/components/sidebar/data-panel/duration_tod_chart.js
+++ b/bikespace_dashboard/js/components/sidebar/data-panel/duration_tod_chart.js
@@ -165,7 +165,7 @@ class DurationTimeOfDayChart extends Component {
   updateCount() {
     // function to check whether report falls into specified duration and parking_time (time of day)
     const test = (dt_string, hours, pd_input, pd_match) => {
-      const dt = new Date(dt_string + "+00:00");
+      const dt = new Date(dt_string + '+00:00');
       const hour_test = hours.includes(dt.getHours());
       const duration_test = pd_input === pd_match;
       return hour_test && duration_test;

--- a/bikespace_dashboard/js/components/sidebar/data-panel/duration_tod_chart.js
+++ b/bikespace_dashboard/js/components/sidebar/data-panel/duration_tod_chart.js
@@ -165,7 +165,7 @@ class DurationTimeOfDayChart extends Component {
   updateCount() {
     // function to check whether report falls into specified duration and parking_time (time of day)
     const test = (dt_string, hours, pd_input, pd_match) => {
-      const dt = new Date(dt_string);
+      const dt = new Date(dt_string + "+00:00");
       const hour_test = hours.includes(dt.getHours());
       const duration_test = pd_input === pd_match;
       return hour_test && duration_test;

--- a/bikespace_dashboard/js/components/sidebar/data-panel/summary_box.js
+++ b/bikespace_dashboard/js/components/sidebar/data-panel/summary_box.js
@@ -1,6 +1,6 @@
 import {Component} from '../../main.js';
 import {DateTime} from '../../../../libraries/luxon.min.js';
-import {parking_time_date_format} from '../../api_tools.js';
+import {parseParkingTime} from '../../api_tools.js';
 
 class SummaryBox extends Component {
   #entryCountDescription = 'reports';
@@ -35,12 +35,11 @@ class SummaryBox extends Component {
 
       // Date Range Description
       const submission_dates = this.shared_state.display_data.map(s =>
-        DateTime.fromFormat(s.parking_time, parking_time_date_format, {
-          zone: 'America/Toronto',
-        })
+        parseParkingTime(s.parking_time)
       );
       const earliest_entry = DateTime.min(...submission_dates);
       const latest_entry = DateTime.max(...submission_dates);
+      console.log(submission_dates, earliest_entry, latest_entry);
 
       this.#dateRangeDescription = `${earliest_entry.toLocaleString(
         DateTime.DATE_FULL,

--- a/bikespace_dashboard/js/components/sidebar/feed/submissions.js
+++ b/bikespace_dashboard/js/components/sidebar/feed/submissions.js
@@ -1,7 +1,7 @@
 import {makeIssueLabelById} from '../../issue_label.js';
 import {Component} from '../../main.js';
 import {
-  parking_duration_attributes as pda, 
+  parking_duration_attributes as pda,
   issue_attributes as ia,
   parseParkingTime,
 } from '../../api_tools.js';
@@ -54,7 +54,7 @@ class Submissions extends Component {
   }
 
   /**
-   * Focus a submission in the submission list panel. 
+   * Focus a submission in the submission list panel.
    * - Applies CSS class to an item to give the feel of it being focused and scroll to it.
    * @param {Number} id ID of the submission to focus
    */
@@ -165,8 +165,8 @@ class Submissions extends Component {
   }
 
   /**
-   * Sorts issues by render priority, then formats them as HTML. 
-   * @param {string[]} issueIds 
+   * Sorts issues by render priority, then formats them as HTML.
+   * @param {string[]} issueIds
    * @returns {string} formatted HTML for issues list
    * @requires issue_label.makeIssueLabel
    * @requires api_tools.issue_attributes
@@ -188,11 +188,12 @@ class Submissions extends Component {
       for (const submission of submissions) {
         const parking_time = parseParkingTime(submission.parking_time);
         const parking_time_desc = parking_time.toLocaleString(
-          {weekday: 'long', month: 'long', day: 'numeric', year: 'numeric'}, 
-          {locale: 'en-CA'},
+          {weekday: 'long', month: 'long', day: 'numeric', year: 'numeric'},
+          {locale: 'en-CA'}
         );
         const parking_time_time = parking_time.toLocaleString(
-          DateTime.TIME_SIMPLE, {locale: 'en-CA'}
+          DateTime.TIME_SIMPLE,
+          {locale: 'en-CA'}
         );
         const html = `
           <a href='#' class="submission-item" 
@@ -200,11 +201,9 @@ class Submissions extends Component {
           >
             <h3>${parking_time_desc}</h3>
             <p class="flex-distribute">
-              <span>${
-                this.#toSentenceCase(parking_time.toRelativeCalendar())
-              } • ${
-                parking_time_time
-              }</span>
+              <span>${this.#toSentenceCase(
+                parking_time.toRelativeCalendar()
+              )} • ${parking_time_time}</span>
               <span class="submission-id">ID: ${submission.id}</span>
             </p>
             <div class="problems">
@@ -214,9 +213,9 @@ class Submissions extends Component {
               pda[submission.parking_duration]?.description ?? 'unknown'
             }</p>
             ${
-              submission.comments 
-              ? `<p><strong>Comments:</strong> ${submission.comments}</p>` 
-              : ''
+              submission.comments
+                ? `<p><strong>Comments:</strong> ${submission.comments}</p>`
+                : ''
             }
           </a>`;
         this.list.append(html);
@@ -237,7 +236,7 @@ class Submissions extends Component {
     }
 
     // parse parking_time into DateTime
-    const submissions_dt = submissions.map((s) => {
+    const submissions_dt = submissions.map(s => {
       s['parking_time_dt'] = parseParkingTime(s.parking_time);
       return s;
     });

--- a/bikespace_dashboard/js/components/sidebar/feed/submissions.js
+++ b/bikespace_dashboard/js/components/sidebar/feed/submissions.js
@@ -3,7 +3,7 @@ import {Component} from '../../main.js';
 import {
   parking_duration_attributes as pda, 
   issue_attributes as ia,
-  parking_time_date_format
+  parseParkingTime,
 } from '../../api_tools.js';
 import {DateTime} from '../../../../libraries/luxon.min.js';
 
@@ -186,11 +186,7 @@ class Submissions extends Component {
       );
     } else {
       for (const submission of submissions) {
-        const parking_time = DateTime.fromFormat(
-          submission.parking_time,
-          parking_time_date_format,
-          {zone: "America/Toronto"}
-        );
+        const parking_time = parseParkingTime(submission.parking_time);
         const parking_time_desc = parking_time.toLocaleString(
           {weekday: 'long', month: 'long', day: 'numeric', year: 'numeric'}, 
           {locale: 'en-CA'},
@@ -242,11 +238,7 @@ class Submissions extends Component {
 
     // parse parking_time into DateTime
     const submissions_dt = submissions.map((s) => {
-      s['parking_time_dt'] = DateTime.fromFormat(
-        s.parking_time,
-        parking_time_date_format,
-        {zone: "America/Toronto"}
-      );
+      s['parking_time_dt'] = parseParkingTime(s.parking_time);
       return s;
     });
 

--- a/bikespace_dashboard/js/components/sidebar/filter-panel/date_filter.js
+++ b/bikespace_dashboard/js/components/sidebar/filter-panel/date_filter.js
@@ -1,6 +1,6 @@
 import {Component, DateRangeFilter} from '../../main.js';
 import {DateTime, Interval} from '../../../../libraries/luxon.min.js';
-import {parking_time_date_format} from '../../api_tools.js';
+import {parseParkingTime} from '../../api_tools.js';
 
 class DateFilterControl extends Component {
   #earliestSelection;
@@ -21,11 +21,7 @@ class DateFilterControl extends Component {
 
     // Calculate date range for all data
     const all_dates = this.shared_state.response_data.map(
-      s => DateTime.fromFormat(
-        s.parking_time,
-        parking_time_date_format,
-        {zone: "America/Toronto"}
-      )
+      s => parseParkingTime(s.parking_time)
     );
     this.#earliestAll = DateTime.min(...all_dates);
     this.#latestAll = DateTime.max(...all_dates);

--- a/bikespace_dashboard/js/components/sidebar/filter-panel/date_filter.js
+++ b/bikespace_dashboard/js/components/sidebar/filter-panel/date_filter.js
@@ -20,110 +20,110 @@ class DateFilterControl extends Component {
     super(parent, root_id, shared_state, options);
 
     // Calculate date range for all data
-    const all_dates = this.shared_state.response_data.map(
-      s => parseParkingTime(s.parking_time)
+    const all_dates = this.shared_state.response_data.map(s =>
+      parseParkingTime(s.parking_time)
     );
     this.#earliestAll = DateTime.min(...all_dates);
     this.#latestAll = DateTime.max(...all_dates);
     this.#earliestSelection = this.#earliestAll;
     this.#latestSelection = this.#latestAll;
-    const today = DateTime.now().setZone("America/Toronto");
+    const today = DateTime.now().setZone('America/Toronto');
 
     this.date_range_options = {
-      "all_dates": {
-        "label": "All Dates",
-        "group": 0,
-        "interval": null,
+      all_dates: {
+        label: 'All Dates',
+        group: 0,
+        interval: null,
       },
-      "last_7_days": {
-        "label": "Last 7 Days",
-        "group": 1,
-        "interval": Interval.fromDateTimes(today.minus({days: 7 - 1}), today),
+      last_7_days: {
+        label: 'Last 7 Days',
+        group: 1,
+        interval: Interval.fromDateTimes(today.minus({days: 7 - 1}), today),
       },
-      "last_30_days": {
-        "label": "Last 30 Days",
-        "group": 1,
-        "interval": Interval.fromDateTimes(today.minus({days: 30 - 1}), today),
+      last_30_days: {
+        label: 'Last 30 Days',
+        group: 1,
+        interval: Interval.fromDateTimes(today.minus({days: 30 - 1}), today),
       },
-      "last_90_days": {
-        "label": "Last 90 Days",
-        "group": 1,
-        "interval": Interval.fromDateTimes(today.minus({days: 90 - 1}), today),
+      last_90_days: {
+        label: 'Last 90 Days',
+        group: 1,
+        interval: Interval.fromDateTimes(today.minus({days: 90 - 1}), today),
       },
       // last 11 full months plus the current month which may be incomplete
-      "last_12_months": {
-        "label": "Last 12 Months",
-        "group": 2,
-        "interval": Interval.fromDateTimes(
-          today.minus({months: 12 - 1}).startOf("month"),
-          today.endOf("month"),
-          ),
-      },
-      "this_year": {
-        "label": "This Year",
-        "group": 2,
-        "interval": Interval.fromDateTimes(
-          today.startOf("year"),
-          today.endOf("year"),
+      last_12_months: {
+        label: 'Last 12 Months',
+        group: 2,
+        interval: Interval.fromDateTimes(
+          today.minus({months: 12 - 1}).startOf('month'),
+          today.endOf('month')
         ),
       },
-      "last_year": {
-        "label": "Last Year",
-        "group": 2,
-        "interval": Interval.fromDateTimes(
-          today.minus({years: 1}).startOf("year"),
-          today.minus({years: 1}).endOf("year"),
+      this_year: {
+        label: 'This Year',
+        group: 2,
+        interval: Interval.fromDateTimes(
+          today.startOf('year'),
+          today.endOf('year')
         ),
       },
-      "custom_range": {
-        "label": "Custom Range",
-        "group": 3,
-        "interval": null,
+      last_year: {
+        label: 'Last Year',
+        group: 2,
+        interval: Interval.fromDateTimes(
+          today.minus({years: 1}).startOf('year'),
+          today.minus({years: 1}).endOf('year')
+        ),
+      },
+      custom_range: {
+        label: 'Custom Range',
+        group: 3,
+        interval: null,
       },
     };
 
-    this.#selection = "all_dates";
+    this.#selection = 'all_dates';
     this.build();
   }
 
   build() {
     const content = [
-      `<details open>`,
-        `<summary>Date Range</summary>`,
-        `<div class="details-container">`,
-          `<div class="filter-section">`,
-            `<div><strong>Showing between:</strong></div>`,
-            `<div id="filter-date-range-indicator" class="">`,
-              `${this.#earliestSelection.toLocaleString(
-                DateTime.DATE_FULL, {locale: 'en-CA'}
-              )} – ${this.#latestSelection.toLocaleString(
-                DateTime.DATE_FULL, {locale: 'en-CA'}
-              )}`,
-            `</div>`,
-          `</div>`,
-          `<div class="filter-section">`,
-            `<div class="filter-section-item">`,
-              `<label for="filter-date-range-select">
+      '<details open>',
+      '<summary>Date Range</summary>',
+      '<div class="details-container">',
+      '<div class="filter-section">',
+      '<div><strong>Showing between:</strong></div>',
+      '<div id="filter-date-range-indicator" class="">',
+      `${this.#earliestSelection.toLocaleString(DateTime.DATE_FULL, {
+        locale: 'en-CA',
+      })} – ${this.#latestSelection.toLocaleString(DateTime.DATE_FULL, {
+        locale: 'en-CA',
+      })}`,
+      '</div>',
+      '</div>',
+      '<div class="filter-section">',
+      '<div class="filter-section-item">',
+      `<label for="filter-date-range-select">
                 <strong>Select:</strong>
               </label>`,
-              `<select name="date-range-select" id="filter-date-range-select">`,
-                `<option value="all_dates">All Dates</option>`,
-                `<hr />`,
-                `<option value="last_7_days">Last 7 days</option>`,
-                `<option value="last_30_days">Last 30 days</option>`,
-                `<option value="last_90_days">Last 90 days</option>`,
-                `<hr />`,
-                `<option value="last_12_months">Last 12 months</option>`,
-                `<option value="this_year">This Year</option>`,
-                `<option value="last_year">Last Year</option>`,
-                `<hr />`,
-                `<option value="custom_range">Custom Range</option>`,
-              `</select>`,
-            `</div>`,
-            `<div class="date-input-group" id="filter-date-input-group" hidden>`,
-              `<div class="date-input filter-section-item">`,
-                `<label for="filter-start-date">Start date:</label>`,
-                `<input 
+      '<select name="date-range-select" id="filter-date-range-select">',
+      '<option value="all_dates">All Dates</option>',
+      '<hr />',
+      '<option value="last_7_days">Last 7 days</option>',
+      '<option value="last_30_days">Last 30 days</option>',
+      '<option value="last_90_days">Last 90 days</option>',
+      '<hr />',
+      '<option value="last_12_months">Last 12 months</option>',
+      '<option value="this_year">This Year</option>',
+      '<option value="last_year">Last Year</option>',
+      '<hr />',
+      '<option value="custom_range">Custom Range</option>',
+      '</select>',
+      '</div>',
+      '<div class="date-input-group" id="filter-date-input-group" hidden>',
+      '<div class="date-input filter-section-item">',
+      '<label for="filter-start-date">Start date:</label>',
+      `<input 
                   type="date" 
                   id="filter-start-date" 
                   name="start-date" 
@@ -131,10 +131,10 @@ class DateFilterControl extends Component {
                   min="${this.#earliestAll.toISODate()}"
                   max="${this.#latestAll.toISODate()}"
                 />`,
-              `</div>`,
-              `<div class="date-input filter-section-item">`,
-                `<label for="filter-end-date">End date:</label>`,
-                `<input 
+      '</div>',
+      '<div class="date-input filter-section-item">',
+      '<label for="filter-end-date">End date:</label>',
+      `<input 
                   type="date" 
                   id="filter-end-date" 
                   name="end-date" 
@@ -142,47 +142,47 @@ class DateFilterControl extends Component {
                   min="${this.#earliestAll.toISODate()}"
                   max="${this.#latestAll.toISODate()}"
                 />`,
-              `</div>`,
-              `<div class="filter-section-item">`,
-                `<button id="filter-date-input-apply" type="button">Apply</button>`,
-              `</div>`,
-            `</div>`,
-          `</div>`,
-        `</div>`,
-      `</details>`,
+      '</div>',
+      '<div class="filter-section-item">',
+      '<button id="filter-date-input-apply" type="button">Apply</button>',
+      '</div>',
+      '</div>',
+      '</div>',
+      '</div>',
+      '</details>',
     ].join('');
 
     $(`#${this.root_id}`).empty().append(content);
 
-    $("#filter-date-range-select").on('change', (e) => {
+    $('#filter-date-range-select').on('change', e => {
       this.#selection = e.target.value;
       this.toggleCustomDatePicker();
-      
+
       // update filter unless custom date picker opened
-      if (this.#selection === "custom_range") return;
+      if (this.#selection === 'custom_range') return;
       const selected_range = this.date_range_options[this.#selection];
       this.setFilter(selected_range.interval);
     });
 
-    $("#filter-date-input-apply").on('click', (e) => {
-      const start_date = $("#filter-start-date").val();
-      const end_date = $("#filter-end-date").val();
+    $('#filter-date-input-apply').on('click', e => {
+      const start_date = $('#filter-start-date').val();
+      const end_date = $('#filter-end-date').val();
       const interval = Interval.fromDateTimes(
-        DateTime.fromISO(start_date, {zone: "America/Toronto"}),
-        DateTime.fromISO(end_date, {zone: "America/Toronto"}),
-      )
+        DateTime.fromISO(start_date, {zone: 'America/Toronto'}),
+        DateTime.fromISO(end_date, {zone: 'America/Toronto'})
+      );
       this.setFilter(interval);
     });
   }
-  
+
   /**
    * Show or hide custom date picker
    */
   toggleCustomDatePicker() {
-    if (this.#selection === "custom_range") {
-      $("#filter-date-input-group").show();
+    if (this.#selection === 'custom_range') {
+      $('#filter-date-input-group').show();
     } else {
-      $("#filter-date-input-group").hide();
+      $('#filter-date-input-group').hide();
     }
   }
 
@@ -190,20 +190,20 @@ class DateFilterControl extends Component {
    * Update UI indicating selected range
    */
   updateSelectedRangeUI() {
-    $("#filter-date-range-indicator").text(
-      `${this.#earliestSelection.toLocaleString(
-        DateTime.DATE_FULL, {locale: 'en-CA'}
-      )} – ${this.#latestSelection.toLocaleString(
-        DateTime.DATE_FULL, {locale: 'en-CA'}
-      )}`
+    $('#filter-date-range-indicator').text(
+      `${this.#earliestSelection.toLocaleString(DateTime.DATE_FULL, {
+        locale: 'en-CA',
+      })} – ${this.#latestSelection.toLocaleString(DateTime.DATE_FULL, {
+        locale: 'en-CA',
+      })}`
     );
-    $("#filter-start-date").val(this.#earliestSelection.toISODate());
-    $("#filter-end-date").val(this.#latestSelection.toISODate());
+    $('#filter-start-date').val(this.#earliestSelection.toISODate());
+    $('#filter-end-date').val(this.#latestSelection.toISODate());
   }
 
   /**
    * set filter for date range
-   * @param {<Interval>} interval 
+   * @param {<Interval>} interval
    */
   setFilter(interval) {
     const filters = this.shared_state.filters;
@@ -215,7 +215,7 @@ class DateFilterControl extends Component {
       delete filters[DateRangeFilter.filterKey];
       this.#earliestSelection = this.#earliestAll;
       this.#latestSelection = this.#latestAll;
-      this.#selection = "all_dates";
+      this.#selection = 'all_dates';
     }
     super.analytics_event(this.root_id, filters);
     this.shared_state.filters = filters;
@@ -226,8 +226,8 @@ class DateFilterControl extends Component {
     if (!this.shared_state.filters[DateRangeFilter.filterKey]) {
       this.#earliestSelection = this.#earliestAll;
       this.#latestSelection = this.#latestAll;
-      this.#selection = "all_dates";
-      $("#filter-date-range-select").val(this.#selection);
+      this.#selection = 'all_dates';
+      $('#filter-date-range-select').val(this.#selection);
       this.toggleCustomDatePicker();
     }
     this.updateSelectedRangeUI();

--- a/bikespace_dashboard/js/components/sidebar/filter-panel/parking_duration_filter.js
+++ b/bikespace_dashboard/js/components/sidebar/filter-panel/parking_duration_filter.js
@@ -23,7 +23,7 @@ class ParkingDurationFilterControl extends Component {
   }
 
   build() {
-    let duration_checkboxes = [`<div>`];
+    const duration_checkboxes = ['<div>'];
     for (const [id, selected] of Object.entries(this.#selection)) {
       duration_checkboxes.push(
         `<div>
@@ -32,7 +32,7 @@ class ParkingDurationFilterControl extends Component {
             id="filter-parking-duration-${id}" 
             name="${id}"
             class="filter-parking-duration-input"
-            ${selected ? "checked" : ""}
+            ${selected ? 'checked' : ''}
           >
           <label for="filter-parking-duration-${id}">
             ${pda[id].description}
@@ -40,47 +40,49 @@ class ParkingDurationFilterControl extends Component {
         </div>`
       );
     }
-    duration_checkboxes.push(`</div>`);
+    duration_checkboxes.push('</div>');
 
     const content = [
-      `<details open>`,
-        `<summary>Parking Duration</summary>`,
-        `<div class="details-container">`,
-          `<div class="parking-duration-types">`,
-            `<button 
+      '<details open>',
+      '<summary>Parking Duration</summary>',
+      '<div class="details-container">',
+      '<div class="parking-duration-types">',
+      `<button 
               class="filter-parking-duration-type" 
               type="button"
               data-type="short-term"
             >
               Short-Term
             </button>`,
-            `<button 
+      `<button 
               class="filter-parking-duration-type" 
               type="button"
               data-type="long-term"
             >
               Long-Term
             </button>`,
-          `</div>`,
-          ...duration_checkboxes,
-        `</div>`,
-      `</details>`,
+      '</div>',
+      ...duration_checkboxes,
+      '</div>',
+      '</details>',
     ].join('');
 
     $(`#${this.root_id}`).empty().append(content);
 
-    $('.filter-parking-duration-input').on('change', (e) => {
-      const checkboxes = document.querySelectorAll('.filter-parking-duration-input');
-      let state = [];
+    $('.filter-parking-duration-input').on('change', e => {
+      const checkboxes = document.querySelectorAll(
+        '.filter-parking-duration-input'
+      );
+      const state = [];
       for (const checkbox of checkboxes) {
         if (checkbox.checked) state.push(checkbox.name);
       }
       this.setFilter(state);
     });
 
-    $('.filter-parking-duration-type').on('click', (e) => {
+    $('.filter-parking-duration-type').on('click', e => {
       const duration_type = e.target.dataset.type;
-      let state = [];
+      const state = [];
       for (const duration of Object.values(pda)) {
         if (duration.type === duration_type) {
           state.push(duration.id);
@@ -93,7 +95,9 @@ class ParkingDurationFilterControl extends Component {
   setFilter(state) {
     const filters = this.shared_state.filters;
     if (state) {
-      filters[ParkingDurationFilter.filterKey] = new ParkingDurationFilter(state);
+      filters[ParkingDurationFilter.filterKey] = new ParkingDurationFilter(
+        state
+      );
       for (const duration of Object.values(pda)) {
         this.#selection[duration.id] = state.includes(duration.id);
       }
@@ -115,8 +119,8 @@ class ParkingDurationFilterControl extends Component {
       }
     }
     for (const [id, selected] of Object.entries(this.#selection)) {
-      document.getElementById(`filter-parking-duration-${id}`)
-        .checked = selected;
+      document.getElementById(`filter-parking-duration-${id}`).checked =
+        selected;
     }
   }
 }


### PR DESCRIPTION
API date format has changed with one of the recent commits:

Old format example: `Sun, 13 Aug 2023 12:36:59 GMT`
New format example: `2024-09-20 1:00:00` (newer entries) or `2024-09-20 03:28:24.632000` (older entries)

Have changed parsing code in the current dashboard to ensure dates are still parsed correctly.

`develop` branch also needs fixing (dates are getting parsed, but in the wrong timezone, e.g. issue id 1407 should display as 8:45am instead of 12:45am).

We should also consider adding end-to-end testing to our test suite to catch integration issues between the API and frontend.

I also updated the linter settings to a more recent ECMA version.