### PR TITLE
Dashboard UI cleanup

### DIFF
--- a/bikespace_frontend/src/components/dashboard/dashboard-header/dashboard-header.module.scss
+++ b/bikespace_frontend/src/components/dashboard/dashboard-header/dashboard-header.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 .header {
   padding: 12px;

--- a/bikespace_frontend/src/components/dashboard/dashboard-header/dashboard-header.module.scss
+++ b/bikespace_frontend/src/components/dashboard/dashboard-header/dashboard-header.module.scss
@@ -52,7 +52,7 @@
   }
 }
 
-@media (max-width: 1024px) {
+@media (max-width: $wrapper-full-width) {
   $nav-width: 250px;
 
   .header {

--- a/bikespace_frontend/src/components/dashboard/dashboard-layout/dashboard-layout.module.scss
+++ b/bikespace_frontend/src/components/dashboard/dashboard-layout/dashboard-layout.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 .dashboardLayout {
   position: relative;

--- a/bikespace_frontend/src/components/dashboard/dashboard-page/dashboard-page.module.scss
+++ b/bikespace_frontend/src/components/dashboard/dashboard-page/dashboard-page.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 .dashboardPage {
   flex-grow: 1;

--- a/bikespace_frontend/src/components/dashboard/dashboard-page/dashboard-page.module.scss
+++ b/bikespace_frontend/src/components/dashboard/dashboard-page/dashboard-page.module.scss
@@ -1,10 +1,12 @@
+@import '@/styles/variables';
+
 .dashboardPage {
   flex-grow: 1;
   display: flex;
   overflow: hidden;
 }
 
-@media (max-width: 1024px) {
+@media (max-width: $wrapper-full-width) {
   .dashboardPage {
     flex-direction: column-reverse;
   }

--- a/bikespace_frontend/src/components/dashboard/data-duration-by-tod-chart/data-duration-by-tod-chart.module.scss
+++ b/bikespace_frontend/src/components/dashboard/data-duration-by-tod-chart/data-duration-by-tod-chart.module.scss
@@ -1,5 +1,5 @@
 @use 'sass:color';
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 $colors: (
   'colorScale0': hsla(

--- a/bikespace_frontend/src/components/dashboard/data-frequency-by-day-chart/data-frequency-by-day-chart.module.scss
+++ b/bikespace_frontend/src/components/dashboard/data-frequency-by-day-chart/data-frequency-by-day-chart.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 $colors: (
   'barColor': $color-primary,

--- a/bikespace_frontend/src/components/dashboard/data-issue-frequency-chart/data-issue-frequency-chart.module.scss
+++ b/bikespace_frontend/src/components/dashboard/data-issue-frequency-chart/data-issue-frequency-chart.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 $colors: (
   'not_provided': $color-secondary-blue,

--- a/bikespace_frontend/src/components/dashboard/feed-submission-item/feed-submision-item.module.scss
+++ b/bikespace_frontend/src/components/dashboard/feed-submission-item/feed-submision-item.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 .item {
   width: 100%;

--- a/bikespace_frontend/src/components/dashboard/feed-submissions/feed-submissions.module.scss
+++ b/bikespace_frontend/src/components/dashboard/feed-submissions/feed-submissions.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 .feed {
   border-radius: 4px;

--- a/bikespace_frontend/src/components/dashboard/filter-date-range-custom/filter-date-range-custom.module.scss
+++ b/bikespace_frontend/src/components/dashboard/filter-date-range-custom/filter-date-range-custom.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 .dateRangeCustom {
   display: flex;

--- a/bikespace_frontend/src/components/dashboard/filter-date-range/filter-date-range.module.scss
+++ b/bikespace_frontend/src/components/dashboard/filter-date-range/filter-date-range.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 .dateRangeSelect {
   select {

--- a/bikespace_frontend/src/components/dashboard/filter-parking-duration/filter-parking-duration.module.scss
+++ b/bikespace_frontend/src/components/dashboard/filter-parking-duration/filter-parking-duration.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 .categoryButtons {
   width: 100%;

--- a/bikespace_frontend/src/components/dashboard/filter-section/filter-section.module.scss
+++ b/bikespace_frontend/src/components/dashboard/filter-section/filter-section.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 .filterSection {
   border-radius: 4px;

--- a/bikespace_frontend/src/components/dashboard/issue-badge/issue-badge.module.scss
+++ b/bikespace_frontend/src/components/dashboard/issue-badge/issue-badge.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 .issue {
   display: inline-block;

--- a/bikespace_frontend/src/components/dashboard/map-handler/MapHandler.tsx
+++ b/bikespace_frontend/src/components/dashboard/map-handler/MapHandler.tsx
@@ -18,28 +18,30 @@ export const MapHandler = () => {
   const [focus] = useSubmissionId();
 
   useEffect(() => {
-    map
-      .locate()
-      .on('locationfound', e => {
-        trackUmamiEvent('locationfound');
+    if (focus === null) {
+      map
+        .locate()
+        .on('locationfound', e => {
+          trackUmamiEvent('locationfound');
 
-        map.flyTo(e.latlng, map.getZoom());
+          map.flyTo(e.latlng, map.getZoom());
 
-        // Stop location tracking after location found
-        map.stopLocate();
-      })
-      .on('locationerror', err => {
-        const code = err.code as 0 | 1 | 2 | 3;
+          // Stop location tracking after location found
+          map.stopLocate();
+        })
+        .on('locationerror', err => {
+          const code = err.code as 0 | 1 | 2 | 3;
 
-        const message =
-          CUSTOM_GEO_ERROR_MESSAGES[code] ||
-          'Unknown error while trying to locate you';
+          const message =
+            CUSTOM_GEO_ERROR_MESSAGES[code] ||
+            'Unknown error while trying to locate you';
 
-        trackUmamiEvent('locationerror', {code: err.code, message});
+          trackUmamiEvent('locationerror', {code: err.code, message});
 
-        console.log(message);
-      });
-  }, []);
+          console.log(message);
+        });
+    }
+  }, []); // [] = run on first render only
 
   useEffect(() => {
     map.invalidateSize();

--- a/bikespace_frontend/src/components/dashboard/map-marker/MapMarker.tsx
+++ b/bikespace_frontend/src/components/dashboard/map-marker/MapMarker.tsx
@@ -34,6 +34,7 @@ import otherIcon from '@/assets/icons/icon_other.svg';
 import markerShadow from 'leaflet/dist/images/marker-shadow.png';
 
 import styles from './map-marker.module.scss';
+import {wrapperFullWidth} from '@/styles/variablesTS';
 
 interface MapMarkerProps {
   submission: SubmissionApiPayload;
@@ -83,7 +84,7 @@ const MapMarker = forwardRef(
     };
 
     const handleClick = () => {
-      if (windowWidth && windowWidth <= 768) {
+      if (windowWidth && windowWidth <= wrapperFullWidth) {
         // Manually set tab= URL params to prevent excess rerendering from subscribing to tab change
         const params = new URLSearchParams(searchParams);
 

--- a/bikespace_frontend/src/components/dashboard/map-marker/MapMarker.tsx
+++ b/bikespace_frontend/src/components/dashboard/map-marker/MapMarker.tsx
@@ -22,7 +22,7 @@ import {issuePriority} from '@/config/bikespace-api';
 
 import {trackUmamiEvent} from '@/utils';
 
-import {SidebarTab, useSubmissionId} from '@/states/url-params';
+import {SidebarTab, useSidebarTab, useSubmissionId} from '@/states/url-params';
 
 import {MapPopup} from '../map-popup';
 
@@ -54,6 +54,7 @@ const MapMarker = forwardRef(
     const innerMarkerRef = useRef<LeafletMarker>(null);
     // pass MarkerRef to parent while also allowing it to be used in this component:
     useImperativeHandle(outerMarkerRef, () => innerMarkerRef.current!, []);
+    const [, setTab] = useSidebarTab();
     const searchParams = useSearchParams();
     const pathname = usePathname();
     const {replace} = useRouter();
@@ -68,6 +69,9 @@ const MapMarker = forwardRef(
     // omits dependencies array to run on every render
     useEffect(() => {
       if (!isFocused || !doneLoading) return;
+      if (windowWidth && windowWidth <= wrapperFullWidth) {
+        setTab(SidebarTab.Feed);
+      }
       clusterRef.current!.zoomToShowLayer(innerMarkerRef.current!, () => {
         innerMarkerRef.current!.openPopup();
       });

--- a/bikespace_frontend/src/components/dashboard/map-popup/map-popup.module.scss
+++ b/bikespace_frontend/src/components/dashboard/map-popup/map-popup.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 .popup {
   font-family: $body-font-stack;

--- a/bikespace_frontend/src/components/dashboard/map-popup/map-popup.module.scss
+++ b/bikespace_frontend/src/components/dashboard/map-popup/map-popup.module.scss
@@ -49,7 +49,7 @@
   align-items: center;
 }
 
-@media (max-width: 768px) {
+@media (max-width: $wrapper-full-width) {
   .popup {
     display: none;
   }

--- a/bikespace_frontend/src/components/dashboard/map/leaflet.scss
+++ b/bikespace_frontend/src/components/dashboard/map/leaflet.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 @import '~leaflet.locatecontrol/dist/L.Control.Locate.css';
 
 .leaflet-bottom {

--- a/bikespace_frontend/src/components/dashboard/report-summary/report-summary.module.scss
+++ b/bikespace_frontend/src/components/dashboard/report-summary/report-summary.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 .summary {
   padding: 4px 8px;

--- a/bikespace_frontend/src/components/dashboard/sidebar-button/sidebar-button.module.scss
+++ b/bikespace_frontend/src/components/dashboard/sidebar-button/sidebar-button.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 .primaryBtn {
   display: flex;

--- a/bikespace_frontend/src/components/dashboard/sidebar-tabs/sidebar-tabs.module.scss
+++ b/bikespace_frontend/src/components/dashboard/sidebar-tabs/sidebar-tabs.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 .tabs {
   display: flex;

--- a/bikespace_frontend/src/components/dashboard/sidebar/sidebar.module.scss
+++ b/bikespace_frontend/src/components/dashboard/sidebar/sidebar.module.scss
@@ -19,7 +19,7 @@
   }
 }
 
-@media (min-width: 1024px) {
+@media (min-width: $wrapper-full-width) {
   .sidebar {
     width: 340px;
   }
@@ -29,7 +29,7 @@
   }
 }
 
-@media (max-width: 1024px) {
+@media (max-width: $wrapper-full-width) {
   $height-panel-handle: 16px;
   $height-panel-handle-bar: 6px;
 

--- a/bikespace_frontend/src/components/dashboard/sidebar/sidebar.module.scss
+++ b/bikespace_frontend/src/components/dashboard/sidebar/sidebar.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 .sidebar {
   background-color: $color-primary-20p;

--- a/bikespace_frontend/src/components/landing/content-blocks/content-blocks.module.scss
+++ b/bikespace_frontend/src/components/landing/content-blocks/content-blocks.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables.scss';
+@import '@/styles/variables.module.scss';
 
 .fullWidth {
   @media (min-width: $wrapper-max-width) {

--- a/bikespace_frontend/src/components/landing/footer/footer.module.scss
+++ b/bikespace_frontend/src/components/landing/footer/footer.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables.scss';
+@import '@/styles/variables.module.scss';
 
 .pageFooter {
   padding: 1rem 1rem 1.62rem 1rem;

--- a/bikespace_frontend/src/components/landing/header/header.module.scss
+++ b/bikespace_frontend/src/components/landing/header/header.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables.scss';
+@import '@/styles/variables.module.scss';
 
 $header-height: 54px;
 

--- a/bikespace_frontend/src/components/landing/landing-layout/landing-layout.module.scss
+++ b/bikespace_frontend/src/components/landing/landing-layout/landing-layout.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables.scss';
+@import '@/styles/variables.module.scss';
 
 $even-lighter-grey: #EEE;
 

--- a/bikespace_frontend/src/components/submission/base-button/base-button.module.scss
+++ b/bikespace_frontend/src/components/submission/base-button/base-button.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 .inputContainer {
   display: flex;

--- a/bikespace_frontend/src/components/submission/submission-form-controller/submission-form-controller.module.scss
+++ b/bikespace_frontend/src/components/submission/submission-form-controller/submission-form-controller.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 .formController {
   display: flex;

--- a/bikespace_frontend/src/components/submission/submission-header/submission-header.module.scss
+++ b/bikespace_frontend/src/components/submission/submission-header/submission-header.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 .header {
   position: sticky;

--- a/bikespace_frontend/src/components/submission/submission-progress-bar/submission-progress-bar.module.scss
+++ b/bikespace_frontend/src/components/submission/submission-progress-bar/submission-progress-bar.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 .progressBar {
   position: relative;

--- a/bikespace_frontend/src/components/submission/time/time.module.scss
+++ b/bikespace_frontend/src/components/submission/time/time.module.scss
@@ -1,4 +1,4 @@
-@import '@/styles/variables';
+@import '@/styles/variables.module.scss';
 
 .submissionTime {
   fieldset > .checkboxGroup {

--- a/bikespace_frontend/src/styles/global.scss
+++ b/bikespace_frontend/src/styles/global.scss
@@ -1,5 +1,5 @@
 @import 'reset';
-@import 'variables';
+@import 'variables.module.scss';
 @import 'typography';
 
 body {

--- a/bikespace_frontend/src/styles/variables.module.scss
+++ b/bikespace_frontend/src/styles/variables.module.scss
@@ -33,3 +33,7 @@ $gray-color: #9b9b9b;
 
 $wrapper-max-width: 640px;
 $wrapper-full-width: 1024px;
+
+:export {
+  wrapperFullWidth: $wrapper-full-width;
+}

--- a/bikespace_frontend/src/styles/variablesTS.ts
+++ b/bikespace_frontend/src/styles/variablesTS.ts
@@ -1,4 +1,8 @@
 // Style variables for use in TSX files - should match CSS variables
-const wrapperFullWidth: number = 1024;
+import styleVars from './variables.module.scss';
+
+// const wrapperFullWidth: number = 1024;
+const wrapperFullWidth = parseInt(styleVars.wrapperFullWidth);
+console.log('width', wrapperFullWidth, styleVars);
 
 export {wrapperFullWidth};

--- a/bikespace_frontend/src/styles/variablesTS.ts
+++ b/bikespace_frontend/src/styles/variablesTS.ts
@@ -1,0 +1,4 @@
+// Style variables for use in TSX files - should match CSS variables
+const wrapperFullWidth: number = 1024;
+
+export {wrapperFullWidth};

--- a/bikespace_frontend/src/styles/variablesTS.ts
+++ b/bikespace_frontend/src/styles/variablesTS.ts
@@ -1,8 +1,6 @@
-// Style variables for use in TSX files - should match CSS variables
+// Style variables for use in TSX files pulls from variables exported from scss
 import styleVars from './variables.module.scss';
 
-// const wrapperFullWidth: number = 1024;
-const wrapperFullWidth = parseInt(styleVars.wrapperFullWidth);
-console.log('width', wrapperFullWidth, styleVars);
+const wrapperFullWidth: number = parseInt(styleVars.wrapperFullWidth);
 
 export {wrapperFullWidth};


### PR DESCRIPTION
Made a couple tweaks to fix some edge cases with the new dashboard UI:

When loading a url with the issue id already specified in the parameters:

- prevents geolocate from moving the map away from the issue pin
- switches to the 'feed' tab on load when below the mobile breakpoint

Mobile breakpoint:

- Standardized to 1024px
- Changed hard-coded instances in scss to use central variable
- Single use of breakpoint in TSX component also inherits from the central scss variable