### PR TITLE
Added scrolling to submission form content

### DIFF
--- a/bikespace_frontend/src/components/submission/location/location.module.scss
+++ b/bikespace_frontend/src/components/submission/location/location.module.scss
@@ -7,5 +7,6 @@
     position: relative;
     flex-grow: 1;
     margin-bottom: 25px;
+    min-height: 200px;
   }
 }

--- a/bikespace_frontend/src/components/submission/submission-form/SubmissionForm.tsx
+++ b/bikespace_frontend/src/components/submission/submission-form/SubmissionForm.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react';
+import React, {useState, useEffect, useRef, useLayoutEffect} from 'react';
 import dynamic from 'next/dynamic';
 
 import {
@@ -82,6 +82,10 @@ export function SubmissionForm() {
 
   const [step, setStep] = useState(0);
 
+  // Scroll to top on each question change
+  const sectionRef = useRef<HTMLElement>(null);
+  useLayoutEffect(() => sectionRef.current?.scroll(0, 0), [step]);
+
   const submissionPayload: SubmissionPayload = {
     latitude: submission.location.latitude,
     longitude: submission.location.longitude,
@@ -101,7 +105,7 @@ export function SubmissionForm() {
         <SubmissionProgressBar step={step} />
       </header>
 
-      <section className={styles.mainContentBody}>
+      <section className={styles.mainContentBody} ref={sectionRef}>
         <SubmissionFormContent
           formOrder={orderedComponents}
           step={step}

--- a/bikespace_frontend/src/components/submission/submission-form/submission-form.module.scss
+++ b/bikespace_frontend/src/components/submission/submission-form/submission-form.module.scss
@@ -36,5 +36,6 @@
     margin: 0 auto;
     padding: 16px 0;
     min-height: 44px;
+    flex-shrink: 0;
   }
 }

--- a/bikespace_frontend/src/components/submission/submission-form/submission-form.module.scss
+++ b/bikespace_frontend/src/components/submission/submission-form/submission-form.module.scss
@@ -14,7 +14,7 @@
     flex-grow: 1;
     width: 90%;
     margin: 0 auto;
-    overflow-y: hidden;
+    overflow-y: scroll;
 
     h2 {
       margin-bottom: 10px;


### PR DESCRIPTION
Fixes #172 

Allows submission form content to scroll, which is especially helpful in the case of reviewing long comments on the submission confirmation page.