### PR TITLE
Bugfix - frontend uses wrong submission post format

### DIFF
--- a/.github/workflows/test-preview.yml
+++ b/.github/workflows/test-preview.yml
@@ -42,6 +42,8 @@ jobs:
         run: make run-pytest
       - name: Coveralls
         uses: coverallsapp/github-action@v2
+        with: 
+          fail-on-error: false
   test-frontend:
     name: Lint and Test Frontend
     runs-on: ubuntu-latest

--- a/bikespace_frontend/src/components/submission/comments/Comments.tsx
+++ b/bikespace_frontend/src/components/submission/comments/Comments.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {useSubmissionFormContext} from '../schema';
+import {useSubmissionFormContext} from '../submission-form/schema';
 
 import {FormSectionHeader} from '../form-section-header';
 

--- a/bikespace_frontend/src/components/submission/comments/comments.test.tsx
+++ b/bikespace_frontend/src/components/submission/comments/comments.test.tsx
@@ -4,7 +4,7 @@ import {render, screen} from '@testing-library/react';
 import {faker} from '@faker-js/faker';
 import {FormProvider, useForm} from 'react-hook-form';
 
-import {SubmissionSchema} from '../schema';
+import {SubmissionSchema} from '../submission-form/schema';
 
 import {Comments} from './Comments';
 

--- a/bikespace_frontend/src/components/submission/constants.ts
+++ b/bikespace_frontend/src/components/submission/constants.ts
@@ -1,5 +1,5 @@
 import {FieldPath} from 'react-hook-form';
-import {SubmissionSchema} from './schema';
+import {SubmissionSchema} from './submission-form/schema';
 
 export const formOrder = [
   'issues',

--- a/bikespace_frontend/src/components/submission/form-section-header/FormSectionHeader.tsx
+++ b/bikespace_frontend/src/components/submission/form-section-header/FormSectionHeader.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import {FieldPath} from 'react-hook-form';
 import {ErrorMessage} from '@hookform/error-message';
 
-import {SubmissionSchema, useSubmissionFormContext} from '../schema';
+import {
+  SubmissionSchema,
+  useSubmissionFormContext,
+} from '../submission-form/schema';
 
 import styles from './form-section-header.module.scss';
 

--- a/bikespace_frontend/src/components/submission/issue/issue.test.tsx
+++ b/bikespace_frontend/src/components/submission/issue/issue.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {render, screen, fireEvent} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import {userEvent} from '@testing-library/user-event';
 import {FormProvider, useForm} from 'react-hook-form';
 
 import {SubmissionSchema} from '../submission-form/schema';
@@ -44,12 +45,14 @@ describe('Issues', () => {
     ).toEqual(expect.arrayContaining(Object.values(IssueType)));
   });
 
-  test('Checking empty checkbox should check issue', () => {
+  test('Checking empty checkbox should check issue', async () => {
     render(<MockIssue />);
 
     const checkbox = screen.getAllByRole('checkbox')[0];
 
-    fireEvent.click(checkbox);
+    const user = userEvent.setup();
+
+    await user.click(checkbox);
 
     expect(checkbox).toBeChecked();
   });
@@ -59,7 +62,9 @@ describe('Issues', () => {
 
     const checkbox = screen.getAllByRole('checkbox')[0];
 
-    fireEvent.click(checkbox);
+    const user = userEvent.setup();
+
+    await user.click(checkbox);
 
     expect(checkbox).not.toBeChecked();
   });

--- a/bikespace_frontend/src/components/submission/issue/issue.test.tsx
+++ b/bikespace_frontend/src/components/submission/issue/issue.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {render, screen, fireEvent} from '@testing-library/react';
 import {FormProvider, useForm} from 'react-hook-form';
 
-import {SubmissionSchema} from '../schema';
+import {SubmissionSchema} from '../submission-form/schema';
 
 import {IssueType} from '@/interfaces/Submission';
 

--- a/bikespace_frontend/src/components/submission/location/Location.tsx
+++ b/bikespace_frontend/src/components/submission/location/Location.tsx
@@ -2,7 +2,7 @@ import {useEffect} from 'react';
 import {MapContainer, TileLayer, Marker} from 'react-leaflet';
 import {LatLngTuple} from 'leaflet';
 
-import {useSubmissionFormContext} from '../schema';
+import {useSubmissionFormContext} from '../submission-form/schema';
 
 import 'leaflet/dist/leaflet.css';
 import 'leaflet-defaulticon-compatibility';

--- a/bikespace_frontend/src/components/submission/location/location.test.tsx
+++ b/bikespace_frontend/src/components/submission/location/location.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {render, screen} from '@testing-library/react';
 import {FormProvider, useForm} from 'react-hook-form';
 
-import {SubmissionSchema} from '../schema';
+import {SubmissionSchema} from '../submission-form/schema';
 
 import {Location} from './Location';
 

--- a/bikespace_frontend/src/components/submission/map-handler/MapHandler.tsx
+++ b/bikespace_frontend/src/components/submission/map-handler/MapHandler.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect} from 'react';
 import {useMapEvent, useMap} from 'react-leaflet';
 
-import {useSubmissionFormContext} from '../schema';
+import {useSubmissionFormContext} from '../submission-form/schema';
 
 export const MapHandler = () => {
   const {setValue} = useSubmissionFormContext();

--- a/bikespace_frontend/src/components/submission/schema.ts
+++ b/bikespace_frontend/src/components/submission/schema.ts
@@ -1,6 +1,10 @@
 import * as z from 'zod';
 
-import {IssueType, ParkingDuration} from '@/interfaces/Submission';
+import {
+  IssueType,
+  ParkingDuration,
+  SubmissionPayload,
+} from '@/interfaces/Submission';
 import {useFormContext} from 'react-hook-form';
 
 export const submissionSchema = z.object({
@@ -23,3 +27,16 @@ export type SubmissionSchema = z.infer<typeof submissionSchema>;
 export const useSubmissionFormContext = () => {
   return useFormContext<SubmissionSchema>();
 };
+
+export function convertSubmissionSchemaToSubmissionPayload(
+  data: SubmissionSchema
+): SubmissionPayload {
+  return {
+    latitude: data.location.latitude,
+    longitude: data.location.longitude,
+    issues: data.issues,
+    parking_time: data.parkingTime.date,
+    parking_duration: data.parkingTime.parkingDuration,
+    comments: data.comments,
+  };
+}

--- a/bikespace_frontend/src/components/submission/select-input/SelectInput.tsx
+++ b/bikespace_frontend/src/components/submission/select-input/SelectInput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useFormContext} from 'react-hook-form';
-import {SubmissionSchema} from '../schema';
+import {SubmissionSchema} from '../submission-form/schema';
 
 import styles from './select-input.module.scss';
 

--- a/bikespace_frontend/src/components/submission/submission-form-controller/SubmissionFormController.tsx
+++ b/bikespace_frontend/src/components/submission/submission-form-controller/SubmissionFormController.tsx
@@ -1,7 +1,7 @@
 import {Route} from 'next';
 import {useRouter} from 'next/navigation';
 
-import {useSubmissionFormContext} from '../schema';
+import {useSubmissionFormContext} from '../submission-form/schema';
 
 import {FormOrder, formOrder} from '../constants';
 

--- a/bikespace_frontend/src/components/submission/submission-form-controller/submission-form-controller.tsx
+++ b/bikespace_frontend/src/components/submission/submission-form-controller/submission-form-controller.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {render, screen} from '@testing-library/react';
 import {FormProvider, useForm} from 'react-hook-form';
 
-import {SubmissionSchema} from '../schema';
+import {SubmissionSchema} from '../submission-form/schema';
 
 import {SubmissionFormController} from './SubmissionFormController';
 

--- a/bikespace_frontend/src/components/submission/submission-form/SubmissionForm.tsx
+++ b/bikespace_frontend/src/components/submission/submission-form/SubmissionForm.tsx
@@ -4,7 +4,11 @@ import {zodResolver} from '@hookform/resolvers/zod';
 
 import {ParkingDuration} from '@/interfaces/Submission';
 
-import {SubmissionSchema, submissionSchema} from '../schema';
+import {
+  convertSubmissionSchemaToSubmissionPayload,
+  SubmissionSchema,
+  submissionSchema,
+} from '../schema';
 
 import {SubmissionProgressBar} from '../submission-progress-bar';
 import {SubmissionFormController} from '../submission-form-controller';
@@ -38,7 +42,9 @@ export function SubmissionForm() {
         `${process.env.BIKESPACE_API_URL}/submissions`,
         {
           method: 'POST',
-          body: JSON.stringify(data),
+          body: JSON.stringify(
+            convertSubmissionSchemaToSubmissionPayload(data)
+          ),
           headers: {
             'Content-Type': 'application/json',
             Accept: 'application/json',

--- a/bikespace_frontend/src/components/submission/submission-form/SubmissionForm.tsx
+++ b/bikespace_frontend/src/components/submission/submission-form/SubmissionForm.tsx
@@ -35,7 +35,7 @@ export function SubmissionForm() {
   const onSubmit = async (data: SubmissionSchema) => {
     try {
       const response = await fetch(
-        'https://api-dev.bikespace.ca/api/v2/submissions',
+        `${process.env.BIKESPACE_API_URL}/submissions`,
         {
           method: 'POST',
           body: JSON.stringify(data),

--- a/bikespace_frontend/src/components/submission/submission-form/SubmissionForm.tsx
+++ b/bikespace_frontend/src/components/submission/submission-form/SubmissionForm.tsx
@@ -1,14 +1,9 @@
 import {useState} from 'react';
 import {useForm, FormProvider} from 'react-hook-form';
-import {zodResolver} from '@hookform/resolvers/zod';
 
 import {ParkingDuration} from '@/interfaces/Submission';
 
-import {
-  convertSubmissionSchemaToSubmissionPayload,
-  SubmissionSchema,
-  submissionSchema,
-} from '../schema';
+import {SubmissionSchema, submissionSchemaResolver} from './schema';
 
 import {SubmissionProgressBar} from '../submission-progress-bar';
 import {SubmissionFormController} from '../submission-form-controller';
@@ -31,7 +26,7 @@ export function SubmissionForm() {
       },
       comments: '',
     },
-    resolver: zodResolver(submissionSchema),
+    resolver: submissionSchemaResolver,
   });
 
   const [step, setStep] = useState<number>(0);
@@ -42,9 +37,14 @@ export function SubmissionForm() {
         `${process.env.BIKESPACE_API_URL}/submissions`,
         {
           method: 'POST',
-          body: JSON.stringify(
-            convertSubmissionSchemaToSubmissionPayload(data)
-          ),
+          body: JSON.stringify({
+            latitude: data.location.latitude,
+            longitude: data.location.longitude,
+            issues: data.issues,
+            parking_time: data.parkingTime.date,
+            parking_duration: data.parkingTime.parkingDuration,
+            comments: data.comments,
+          }),
           headers: {
             'Content-Type': 'application/json',
             Accept: 'application/json',

--- a/bikespace_frontend/src/components/submission/submission-form/schema.ts
+++ b/bikespace_frontend/src/components/submission/submission-form/schema.ts
@@ -1,10 +1,7 @@
 import * as z from 'zod';
+import {zodResolver} from '@hookform/resolvers/zod';
 
-import {
-  IssueType,
-  ParkingDuration,
-  SubmissionPayload,
-} from '@/interfaces/Submission';
+import {IssueType, ParkingDuration} from '@/interfaces/Submission';
 import {useFormContext} from 'react-hook-form';
 
 export const submissionSchema = z.object({
@@ -28,15 +25,4 @@ export const useSubmissionFormContext = () => {
   return useFormContext<SubmissionSchema>();
 };
 
-export function convertSubmissionSchemaToSubmissionPayload(
-  data: SubmissionSchema
-): SubmissionPayload {
-  return {
-    latitude: data.location.latitude,
-    longitude: data.location.longitude,
-    issues: data.issues,
-    parking_time: data.parkingTime.date,
-    parking_duration: data.parkingTime.parkingDuration,
-    comments: data.comments,
-  };
-}
+export const submissionSchemaResolver = zodResolver(submissionSchema);

--- a/bikespace_frontend/src/components/submission/summary/Summary.tsx
+++ b/bikespace_frontend/src/components/submission/summary/Summary.tsx
@@ -1,4 +1,4 @@
-import {useSubmissionFormContext} from '../schema';
+import {useSubmissionFormContext} from '../submission-form/schema';
 
 import styles from './summary.module.scss';
 

--- a/bikespace_frontend/src/components/submission/summary/summary.test.tsx
+++ b/bikespace_frontend/src/components/submission/summary/summary.test.tsx
@@ -4,7 +4,8 @@ import {
   FieldErrors,
   UseFormReturn,
 } from 'react-hook-form';
-import {fireEvent, render, screen, act} from '@testing-library/react';
+import {render, screen, act} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import {SubmissionSchema} from '../submission-form/schema';
 
@@ -81,9 +82,9 @@ describe('Summary', () => {
 
     const submitButton = screen.getByText('Submit');
 
-    await act(() => {
-      fireEvent.click(submitButton);
-    });
+    const user = userEvent.setup();
+
+    await user.click(submitButton);
 
     expect(screen.getByRole('heading', {level: 1})).toHaveTextContent(
       'Success'
@@ -101,9 +102,9 @@ describe('Summary', () => {
 
     const submitButton = screen.getByText('Submit');
 
-    await act(() => {
-      fireEvent.click(submitButton);
-    });
+    const user = userEvent.setup();
+
+    await user.click(submitButton);
 
     expect(
       screen.getByText(
@@ -123,9 +124,9 @@ describe('Summary', () => {
 
     const submitButton = screen.getByText('Submit');
 
-    await act(() => {
-      fireEvent.click(submitButton);
-    });
+    const user = userEvent.setup();
+
+    await user.click(submitButton);
 
     expect(screen.getByText(/Something went wrong beyond our expectations/));
   });

--- a/bikespace_frontend/src/components/submission/summary/summary.test.tsx
+++ b/bikespace_frontend/src/components/submission/summary/summary.test.tsx
@@ -6,7 +6,7 @@ import {
 } from 'react-hook-form';
 import {fireEvent, render, screen, act} from '@testing-library/react';
 
-import {SubmissionSchema} from '../schema';
+import {SubmissionSchema} from '../submission-form/schema';
 
 import {formOrder} from '../constants';
 

--- a/bikespace_frontend/src/components/submission/time/Time.tsx
+++ b/bikespace_frontend/src/components/submission/time/Time.tsx
@@ -1,6 +1,6 @@
 import {ParkingDuration} from '@/interfaces/Submission';
 
-import {useSubmissionFormContext} from '../schema';
+import {useSubmissionFormContext} from '../submission-form/schema';
 
 import {FormSectionHeader} from '../form-section-header';
 import {SelectInput} from '../select-input';

--- a/bikespace_frontend/src/components/submission/time/time.test.tsx
+++ b/bikespace_frontend/src/components/submission/time/time.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {render, screen, fireEvent} from '@testing-library/react';
+import {render, screen, fireEvent, act} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {FormProvider, useForm} from 'react-hook-form';
 
 import {SubmissionSchema} from '../submission-form/schema';
@@ -48,13 +49,15 @@ describe('Time', () => {
     expect(screen.getByText(/multiday/i));
   });
 
-  test('Changing parking duration correctly updates state', () => {
+  test('Changing parking duration correctly updates state', async () => {
     render(<MockForm />);
 
     const radios = screen.getAllByRole('radio');
     const radio = radios[1];
 
-    fireEvent.click(radio);
+    const user = userEvent.setup();
+
+    await user.click(radio);
 
     expect(radio).toBeChecked();
   });
@@ -66,7 +69,9 @@ describe('Time', () => {
 
     const dateTime = screen.getByTestId('when');
 
-    fireEvent.change(dateTime, {target: {value: inputDate}});
+    act(() => {
+      fireEvent.change(dateTime, {target: {value: inputDate}});
+    });
 
     expect(dateTime).toHaveValue(inputDate);
   });

--- a/bikespace_frontend/src/components/submission/time/time.test.tsx
+++ b/bikespace_frontend/src/components/submission/time/time.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {render, screen, fireEvent} from '@testing-library/react';
 import {FormProvider, useForm} from 'react-hook-form';
 
-import {SubmissionSchema} from '../schema';
+import {SubmissionSchema} from '../submission-form/schema';
 
 import {ParkingDuration} from '@/interfaces/Submission';
 


### PR DESCRIPTION
Issue: front end does not provide data to the /submissions [POST] route in the expected format.

To replicate: run the frontend and API locally and try making a submission.

Fix provided here: add a converter function between `SubmissionSchema` and `SubmissionPayload`. Also fixed hard-coding of API url.