### PR TITLE
Bump up buildpack python version to supported 3.12.8 version

### DIFF
--- a/bikespace_api/fly.toml
+++ b/bikespace_api/fly.toml
@@ -11,7 +11,7 @@ processes = []
   buildpacks = ["paketo-buildpacks/python"]
 
 [build.args]
-  BP_CPYTHON_VERSION = "3.12.4"
+  BP_CPYTHON_VERSION = "3.12.8"
 
 [env]
   PORT = "8000"


### PR DESCRIPTION
Python 3.12.4 isn't supported on the paketo buildpacks anymore.
Bumping python version to 3.12.8 for fly.io