### PR TITLE
Remove db stamps head from fly_release.sh

### DIFF
--- a/bikespace_api/fly_release.sh
+++ b/bikespace_api/fly_release.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env sh
 
-python manage.py db stamp heads --directory migrations
 python manage.py db upgrade --directory migrations


### PR DESCRIPTION
- Remove db stamp heads command before applying the migrations