### PR TITLE
Ignore archive in vscode’s file search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.exclude": {
+    "archive/": true
+  }
+}


### PR DESCRIPTION
I keep getting results from the archive and confusing myself when using `cmd` + `p`