### PR TITLE
Skip coveralls if they have a service outage

### DIFF
--- a/.github/workflows/deploy-app-bikespace-redirect-page.yml
+++ b/.github/workflows/deploy-app-bikespace-redirect-page.yml
@@ -2,24 +2,24 @@ name: Deploy Landing Page Redirect
 on:
   push:
     branches:
-        - main
+      - main
     paths:
-        - archive/redirect-app-bikespace-ca/index.html
+      - archive/redirect-app-bikespace-ca/index.html
 jobs:
-    deploy-to-cloudflare:
-        name: Deploy to Cloudflare
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-            deployments: write
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v3
-            - name: Publish to Cloudflare Pages
-              uses: cloudflare/pages-action@v1.0.0
-              with:
-                apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-                accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-                projectName: app-bikespace-redirect
-                directory: ./archive/redirect-app-bikespace-ca/
-                gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+  deploy-to-cloudflare:
+    name: Deploy to Cloudflare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Publish to Cloudflare Pages
+        uses: cloudflare/pages-action@v1.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: app-bikespace-redirect
+          directory: ./archive/redirect-app-bikespace-ca/
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-old-dashboard-redirect-page.yml
+++ b/.github/workflows/deploy-old-dashboard-redirect-page.yml
@@ -2,24 +2,24 @@ name: Deploy Dashboard Redirect
 on:
   push:
     branches:
-        - main
+      - main
     paths:
-        - archive/redirect-dashboard-bikespace-ca/index.html
+      - archive/redirect-dashboard-bikespace-ca/index.html
 jobs:
-    deploy-to-cloudflare:
-        name: Deploy to Cloudflare
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-            deployments: write
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v3
-            - name: Publish to Cloudflare Pages
-              uses: cloudflare/pages-action@v1.0.0
-              with:
-                apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-                accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-                projectName: dashboard-bikespace-redirect
-                directory: ./archive/redirect-dashboard-bikespace-ca/
-                gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+  deploy-to-cloudflare:
+    name: Deploy to Cloudflare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Publish to Cloudflare Pages
+        uses: cloudflare/pages-action@v1.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: dashboard-bikespace-redirect
+          directory: ./archive/redirect-dashboard-bikespace-ca/
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-to-fly.yml
+++ b/.github/workflows/deploy-to-fly.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version : '3.12.0'
+          python-version: "3.12.0"
       - name: Run pytest
         run: make test-api
       - name: Coveralls
@@ -63,20 +63,20 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version : '3.12.0'
+          python-version: "3.12.0"
       - name: Run migration check
         run: make migrate-test-db
   deploy-to-fly:
-      name: Deploy to fly.io
-      needs: [apitest, api-migration-test]
-      runs-on: ubuntu-latest
-      permissions:
-        contents: read
-        deployments: write
-      steps:
-        - uses: actions/checkout@v3
-        - uses: superfly/flyctl-actions/setup-flyctl@master
-        - run: flyctl deploy 
-          working-directory: ./bikespace_api
-          env:
-            FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+    name: Deploy to fly.io
+    needs: [apitest, api-migration-test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy
+        working-directory: ./bikespace_api
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/deploy-to-fly.yml
+++ b/.github/workflows/deploy-to-fly.yml
@@ -38,6 +38,8 @@ jobs:
         run: make test-api
       - name: Coveralls
         uses: coverallsapp/github-action@v2
+        with:
+          fail-on-error: false
   api-migration-test:
     name: Test if database migrations need to be generated for API
     runs-on: ubuntu-latest

--- a/.github/workflows/test-preview.yml
+++ b/.github/workflows/test-preview.yml
@@ -3,8 +3,8 @@ on:
   pull_request:
     types: [opened, synchronize, edited, ready_for_review]
     paths:
-        - bikespace_api/**
-        - bikespace_frontend/**
+      - bikespace_api/**
+      - bikespace_frontend/**
 jobs:
   apitest:
     name: API tests
@@ -32,14 +32,14 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version : '3.12.0'
-          cache: 'pip'
+          python-version: "3.12.0"
+          cache: "pip"
           cache-dependency-path: bikespace_api/requirements.txt
       - name: Run pytest
         run: make test-api
       - name: Coveralls
         uses: coverallsapp/github-action@v2
-        with: 
+        with:
           fail-on-error: false
   api-migration-test:
     name: Test if database migrations need to be generated for API
@@ -66,8 +66,8 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version : '3.12.0'
-          cache: 'pip'
+          python-version: "3.12.0"
+          cache: "pip"
           cache-dependency-path: bikespace_api/requirements.txt
       - name: Run migration check
         run: make migrate-test-db
@@ -75,18 +75,18 @@ jobs:
     name: Lint and Test Frontend
     runs-on: ubuntu-latest
     steps:
-        - name: Checkout
-          uses: actions/checkout@v4
-        - name: Setup node
-          uses: actions/setup-node@v4
-          with:
-            node-version: lts/*
-            cache: 'npm'
-            cache-dependency-path: bikespace_frontend/package-lock.json
-        - name: Check code style
-          run: make lint-frontend
-        - name: Run Jest tests
-          run: make test-frontend
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: "npm"
+          cache-dependency-path: bikespace_frontend/package-lock.json
+      - name: Check code style
+        run: make lint-frontend
+      - name: Run Jest tests
+        run: make test-frontend
   test-e2e:
     name: Frontend end-to-end tests
     timeout-minutes: 10
@@ -109,22 +109,22 @@ jobs:
         ports:
           - 5432:5432
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Setup node
-      uses: actions/setup-node@v4
-      with:
-        node-version: lts/*
-        cache: 'npm'
-        cache-dependency-path: bikespace_frontend/package-lock.json
-    - name: Run end to end tests
-      run: make test-e2e
-    - uses: actions/upload-artifact@v4
-      if: ${{ !cancelled() }}
-      with:
-        name: playwright-report
-        path: bikespace_frontend/playwright-report/
-        retention-days: 30
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: "npm"
+          cache-dependency-path: bikespace_frontend/package-lock.json
+      - name: Run end to end tests
+        run: make test-e2e
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: bikespace_frontend/playwright-report/
+          retention-days: 30
   publish:
     name: Publish to Cloudflare Pages
     needs: [test-frontend, test-e2e]
@@ -144,7 +144,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: bikespace_frontend/package-lock.json
       - name: Build static frontend
         run: make build-frontend
@@ -156,5 +156,3 @@ jobs:
           projectName: bikespace-v2
           directory: bikespace_frontend/out
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-
-  


### PR DESCRIPTION
Adds `fail-on-error: false` to the deploy-to-fly action. (`fail-on-error: false` is already configured for test-preview) This prevents API deployment from being blocked by a coveralls service outage.

Also linted the workflow files.