### PR TITLE
Add "fog of war" visualization to LTS map

### DIFF
--- a/bikespace_frontend/src/components/lts-map/lts-map-page/LtsMapPage.tsx
+++ b/bikespace_frontend/src/components/lts-map/lts-map-page/LtsMapPage.tsx
@@ -21,6 +21,7 @@ import {
 import {SidebarButton} from '@/components/shared-ui/sidebar-button';
 
 import type {
+  HeatmapLayer,
   LineLayer,
   MapLayerMouseEvent,
   MapRef,
@@ -115,6 +116,40 @@ const ltsSelectedLayer: LineLayer = {
       ],
     },
     'line-color': '#ff6f00',
+  },
+};
+
+const fogOfWarFilter: FilterSpecification = [
+  'in',
+  ['get', 'lts'],
+  ['literal', [1]],
+];
+
+const ltsFogOfWarLayer: HeatmapLayer = {
+  id: 'lts-fog-of-war',
+  type: 'heatmap',
+  source: 'lts',
+  'source-layer': ltsSourceLayer,
+  paint: {
+    'heatmap-intensity': 10,
+    'heatmap-radius': [
+      'interpolate',
+      ['exponential', 2],
+      ['zoom'],
+      10,
+      1,
+      20,
+      2048,
+    ],
+    'heatmap-color': [
+      'interpolate',
+      ['linear'],
+      ['heatmap-density'],
+      0,
+      'rgba(0,0,0,0.5)',
+      1,
+      'rgba(0,0,0,0)',
+    ],
   },
 };
 
@@ -518,6 +553,7 @@ export function LtsMapPage() {
         <Source id="lts" type="vector" url={ltsPmtilesUrl}>
           <Layer {...ltsLineLayer} filter={ltsFilter} beforeId="Road labels" />
           <Layer {...ltsHitLayer} filter={ltsFilter} beforeId="Road labels" />
+          <Layer {...ltsFogOfWarLayer} filter={fogOfWarFilter} />
         </Source>
         {selectedFeatureGeoJSON ? (
           <Source


### PR DESCRIPTION
Inspired by [Daniel Schep's "Fog of War on Cars" visualization](https://osmus.slack.com/archives/C01G3D28DAB/p1771249467207579?thread_ts=1769813366.387619&cid=C01G3D28DAB) - adds a heatmap layer that darkens any area outside of a radius near an LTS 1 feature.

To do:

- [ ] Discuss if this is an optional feature we want to add
- [ ] Add in UI to turn on/off and control (e.g. radius, alpha, which LTS levels to include)
- [ ] Check to make sure there are no big performance impacts on the map