### PR TITLE
Switch analytics to self hosted

### DIFF
--- a/bikespace_frontend/src/config/umami.ts
+++ b/bikespace_frontend/src/config/umami.ts
@@ -1,4 +1,4 @@
 export const umamiConfig = {
-  websiteId: 'd56aa43e-3009-4f6d-9975-c82af706c3be',
-  hostUrl: 'https://us.umami.is/script.js',
+  websiteId: '1a10973e-d4de-4ac1-98d6-23019ffe60bf',
+  hostUrl: 'https://analytics.bikespaceproject.ca/script.js',
 };

--- a/bikespace_frontend/src/utils/track-umami-event.ts
+++ b/bikespace_frontend/src/utils/track-umami-event.ts
@@ -6,6 +6,7 @@ umami.init(umamiConfig);
 
 export const trackUmamiEvent = (eventName: string, data?: UmamiEventData) => {
   // Disable tracking during development
+  // Tracking calls during testing _should_ be caught by mocks
   if (process.env.NODE_ENV === 'development') return;
 
   umami.track(eventName, data);


### PR DESCRIPTION
Switches frontend analytics to point to self-hosted instance.

Once the change is live, will follow the export-import steps to port over the data from Umami cloud as noted here: https://tallcoleman.me/programming/2026/02/23/migrate-umami-cloud-to-self-hosted.html