### PR TITLE
Small design fixes for map pages

### DIFF
--- a/.github/workflows/test-preview.yml
+++ b/.github/workflows/test-preview.yml
@@ -142,15 +142,15 @@ jobs:
           retention-days: 30
   publish:
     # Only publish previews for PRs from the same repository
-    if : ${{ github.event.pull_request.head.repo.full_name == github.repository}}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository}}
     name: Publish to Cloudflare Pages
     needs: [test-frontend, test-e2e]
     runs-on: ubuntu-latest
     env:
       MAPTILER_API_KEY: ${{ secrets.MAPTILER_API_KEY }}
-      DATA_BICYCLE_PARKING: ${{ secrets.DATA_BICYCLE_PARKING }}
-      DATA_BICYCLE_NETWORK: ${{ secrets.DATA_BICYCLE_NETWORK }}
-      DATA_LEVEL_OF_TRAFFIC_STRESS: ${{ secrets.DATA_LEVEL_OF_TRAFFIC_STRESS }}
+      # DATA_BICYCLE_PARKING: ${{ secrets.DATA_BICYCLE_PARKING }}
+      # DATA_BICYCLE_NETWORK: ${{ secrets.DATA_BICYCLE_NETWORK }}
+      # DATA_LEVEL_OF_TRAFFIC_STRESS: ${{ secrets.DATA_LEVEL_OF_TRAFFIC_STRESS }}
     permissions:
       contents: read
       deployments: write

--- a/.github/workflows/test-preview.yml
+++ b/.github/workflows/test-preview.yml
@@ -148,9 +148,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MAPTILER_API_KEY: ${{ secrets.MAPTILER_API_KEY }}
-      # DATA_BICYCLE_PARKING: ${{ secrets.DATA_BICYCLE_PARKING }}
-      # DATA_BICYCLE_NETWORK: ${{ secrets.DATA_BICYCLE_NETWORK }}
-      # DATA_LEVEL_OF_TRAFFIC_STRESS: ${{ secrets.DATA_LEVEL_OF_TRAFFIC_STRESS }}
     permissions:
       contents: read
       deployments: write

--- a/bikespace_frontend/src/components/dashboard/feed-submission-item/feed-submision-item.module.scss
+++ b/bikespace_frontend/src/components/dashboard/feed-submission-item/feed-submision-item.module.scss
@@ -15,6 +15,14 @@
     font-size: medium;
   }
 
+  // prevent long words (e.g. urls) from breaking the layout
+  p {
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    // specific fix for Safari on iOS
+    word-break: break-word;
+  }
+
   .subHeader {
     width: 100%;
     display: flex;

--- a/bikespace_frontend/src/components/dashboard/map-popup/map-popup.module.scss
+++ b/bikespace_frontend/src/components/dashboard/map-popup/map-popup.module.scss
@@ -2,6 +2,15 @@
 
 .popup {
   font-family: $body-font-stack;
+
+  // prevent long words (e.g. urls) from breaking the layout
+  p {
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    // specific fix for Safari on iOS
+    // unlikely that this is needed, since the viewport would have to be full-screen size to show pop-ups, but just in case (e.g. big iPads)
+    word-break: break-word;
+  }
 }
 
 .submissionId {

--- a/bikespace_frontend/src/components/lts-map/lts-map-page/LtsMapPage.tsx
+++ b/bikespace_frontend/src/components/lts-map/lts-map-page/LtsMapPage.tsx
@@ -130,6 +130,13 @@ export function LtsMapPage() {
   const mapRef = useRef<MapRef>(null);
   const resultsCardRef = useRef<HTMLDivElement>(null);
 
+  const mapStyle = process.env.MAPTILER_API_KEY
+    ? `https://api.maptiler.com/maps/dataviz/style.json?key=${process.env.MAPTILER_API_KEY}`
+    : backupMapStyle;
+  const mapStyleRoadLabelsLayer = process.env.MAPTILER_API_KEY
+    ? 'Road labels'
+    : 'roads_labels_major';
+
   const ltsFilter: FilterSpecification =
     enabledLtsLevels.length === 0
       ? ['==', ['get', 'lts'], -1]
@@ -538,11 +545,7 @@ export function LtsMapPage() {
           zoom: 12,
         }}
         style={{width: '100%', height: '100%'}}
-        mapStyle={
-          process.env.MAPTILER_API_KEY
-            ? `https://api.maptiler.com/maps/dataviz/style.json?key=${process.env.MAPTILER_API_KEY}`
-            : backupMapStyle
-        }
+        mapStyle={mapStyle}
         onLoad={handleOnLoad}
         onClick={handleMapClick}
         onError={event => {
@@ -554,8 +557,16 @@ export function LtsMapPage() {
         <NavigationControl position="top-left" />
         <GeolocateControl position="top-left" />
         <Source id="lts" type="vector" url={ltsPmtilesUrl}>
-          <Layer {...ltsLineLayer} filter={ltsFilter} beforeId="Road labels" />
-          <Layer {...ltsHitLayer} filter={ltsFilter} beforeId="Road labels" />
+          <Layer
+            {...ltsLineLayer}
+            filter={ltsFilter}
+            beforeId={mapStyleRoadLabelsLayer}
+          />
+          <Layer
+            {...ltsHitLayer}
+            filter={ltsFilter}
+            beforeId={mapStyleRoadLabelsLayer}
+          />
         </Source>
         {selectedFeatureGeoJSON ? (
           <Source
@@ -563,7 +574,7 @@ export function LtsMapPage() {
             type="geojson"
             data={selectedFeatureGeoJSON}
           >
-            <Layer {...ltsSelectedLayer} beforeId="Road labels" />
+            <Layer {...ltsSelectedLayer} beforeId={mapStyleRoadLabelsLayer} />
           </Source>
         ) : null}
       </Map>

--- a/bikespace_frontend/src/components/map-layers/parking/parking-feature-description/ParkingFeatureDescription.tsx
+++ b/bikespace_frontend/src/components/map-layers/parking/parking-feature-description/ParkingFeatureDescription.tsx
@@ -17,6 +17,7 @@ export interface ParkingFeatureDescriptionProps {
   handleClick: Function;
   handleHover: Function;
   handleUnHover: Function;
+  centerFeatureOnMap: Function;
 }
 
 export function ParkingFeatureDescription({
@@ -26,6 +27,7 @@ export function ParkingFeatureDescription({
   handleClick,
   handleHover,
   handleUnHover,
+  centerFeatureOnMap,
 }: ParkingFeatureDescriptionProps) {
   if (!feature.properties) {
     return <p>Feature has no properties</p>;
@@ -219,11 +221,13 @@ export function ParkingFeatureDescription({
         <SourceLink feature={feature} />
         <div className={styles.featureDescriptionControls}>
           <SidebarButton
-            onClick={(e: React.MouseEvent) => handleClick(e, feature)}
-            disabled={selected}
+            onClick={(e: React.MouseEvent) => {
+              centerFeatureOnMap(feature);
+              if (!selected) handleClick(e, feature);
+            }}
             umamiEvent="parking-feature-select-on-map"
           >
-            Select{selected ? 'ed' : ''} on Map
+            {selected ? 'Center on Map' : 'Select on Map'}
           </SidebarButton>
           <SidebarButton
             onClick={() => setShowAllData(!showAllData)}

--- a/bikespace_frontend/src/components/map-layers/parking/parking-feature-description/parking-feature-description.module.scss
+++ b/bikespace_frontend/src/components/map-layers/parking/parking-feature-description/parking-feature-description.module.scss
@@ -55,7 +55,7 @@
     flex-basis: 100%;
     border: 2px solid $color-primary-20p;
     height: 2rem * 0.9;
-    font-size: 0.9rem;
+    font-size: 0.85rem;
   }
 }
 

--- a/bikespace_frontend/src/components/map-layers/parking/parking-feature-description/parking-feature-description.test.tsx
+++ b/bikespace_frontend/src/components/map-layers/parking/parking-feature-description/parking-feature-description.test.tsx
@@ -13,6 +13,7 @@ const testParkingData = testParkingDataSrc as FeatureCollection;
 const mockHandleClick = jest.fn();
 const mockHandleHover = jest.fn();
 const mockHandleUnHover = jest.fn();
+const mockCenterFeatureOnMap = jest.fn();
 
 function ContextMock() {
   const [selected, setSelected] = useState<boolean>(false);
@@ -26,12 +27,13 @@ function ContextMock() {
       handleClick={handleClick}
       handleHover={mockHandleHover}
       handleUnHover={mockHandleUnHover}
+      centerFeatureOnMap={mockCenterFeatureOnMap}
     />
   );
 }
 
 describe('ParkingFeatureDescription', () => {
-  test('Selecting the feature should lock the select button', async () => {
+  test('Selecting the feature should change the select button to map centering', async () => {
     const user = userEvent.setup();
     render(<ContextMock />);
 
@@ -39,7 +41,7 @@ describe('ParkingFeatureDescription', () => {
       selector: 'button',
     });
     await user.click(selectFeatureButton);
-    expect(selectFeatureButton).toBeDisabled();
+    expect(selectFeatureButton).toHaveTextContent(/center/i);
   });
 
   test('Toggling show/hide all data should show/hide all data', async () => {
@@ -52,6 +54,7 @@ describe('ParkingFeatureDescription', () => {
         handleClick={mockHandleClick}
         handleHover={mockHandleHover}
         handleUnHover={mockHandleUnHover}
+        centerFeatureOnMap={mockCenterFeatureOnMap}
       />
     );
 

--- a/bikespace_frontend/src/components/parking-map/parking-map-page/ParkingMapPage.tsx
+++ b/bikespace_frontend/src/components/parking-map/parking-map-page/ParkingMapPage.tsx
@@ -85,10 +85,10 @@ export function ParkingMapPage() {
   const resultsCardRef = useRef<HTMLDivElement>(null);
 
   const mapStyle = process.env.MAPTILER_API_KEY
-    ? `https://api.maptiler.com/maps/streets/style.json?key=${process.env.MAPTILER_API_KEY}`
+    ? `https://api.maptiler.com/maps/dataviz/style.json?key=${process.env.MAPTILER_API_KEY}`
     : backupMapStyle;
   const mapStyleRoadLabelsLayer = process.env.MAPTILER_API_KEY
-    ? 'road_label'
+    ? 'Road labels'
     : 'roads_labels_major';
 
   // enable backup map tiles

--- a/bikespace_frontend/src/components/parking-map/parking-map-page/ParkingMapPage.tsx
+++ b/bikespace_frontend/src/components/parking-map/parking-map-page/ParkingMapPage.tsx
@@ -22,7 +22,6 @@ import {
 import {Spinner} from '@/components/shared-ui/spinner';
 import {
   ParkingFeatureDescription,
-  parkingFirstLayerId,
   parkingInteractiveLayers,
   ParkingLayer,
   ParkingLayerLegend,
@@ -84,6 +83,13 @@ export function ParkingMapPage() {
 
   const mapRef = useRef<MapRef>(null);
   const resultsCardRef = useRef<HTMLDivElement>(null);
+
+  const mapStyle = process.env.MAPTILER_API_KEY
+    ? `https://api.maptiler.com/maps/streets/style.json?key=${process.env.MAPTILER_API_KEY}`
+    : backupMapStyle;
+  const mapStyleRoadLabelsLayer = process.env.MAPTILER_API_KEY
+    ? 'road_label'
+    : 'roads_labels_major';
 
   // enable backup map tiles
   useEffect(() => {
@@ -309,11 +315,7 @@ export function ParkingMapPage() {
           zoom: zoomLevel,
         }}
         style={{width: '100%', height: '100%'}}
-        mapStyle={
-          process.env.MAPTILER_API_KEY
-            ? `https://api.maptiler.com/maps/streets/style.json?key=${process.env.MAPTILER_API_KEY}`
-            : backupMapStyle
-        }
+        mapStyle={mapStyle}
         onLoad={handleOnLoad}
         onClick={handleLayerClick}
         // onZoomEnd={() =>
@@ -328,7 +330,7 @@ export function ParkingMapPage() {
           layerFilter={parkingLayerFilter}
         />
         {showBicycleNetwork ? (
-          <BicycleNetworkLayer beforeId={parkingFirstLayerId} />
+          <BicycleNetworkLayer beforeId={mapStyleRoadLabelsLayer} />
         ) : null}
         {/* placed here to avoid covering the sidebar */}
         <Spinner show={isMapLoading} overlay label="Loading map..." />

--- a/bikespace_frontend/src/components/parking-map/parking-map-page/ParkingMapPage.tsx
+++ b/bikespace_frontend/src/components/parking-map/parking-map-page/ParkingMapPage.tsx
@@ -151,6 +151,10 @@ export function ParkingMapPage() {
     });
   }
 
+  function zoomAndFlyToSingleFeature(feature: MapGeoJSONFeature) {
+    zoomAndFlyTo([feature]);
+  }
+
   function handleLayerClick(e: MapLayerMouseEvent) {
     const features = mapRef.current!.queryRenderedFeatures(
       e.point as PointLike,
@@ -268,6 +272,7 @@ export function ParkingMapPage() {
                 handleClick={handleFeatureSelection}
                 handleHover={handleFeatureHover}
                 handleUnHover={handleFeatureUnHover}
+                centerFeatureOnMap={zoomAndFlyToSingleFeature}
               />
             ))}
           </div>

--- a/bikespace_frontend/src/components/parking-map/parking-map-page/ParkingMapPage.tsx
+++ b/bikespace_frontend/src/components/parking-map/parking-map-page/ParkingMapPage.tsx
@@ -85,10 +85,10 @@ export function ParkingMapPage() {
   const resultsCardRef = useRef<HTMLDivElement>(null);
 
   const mapStyle = process.env.MAPTILER_API_KEY
-    ? `https://api.maptiler.com/maps/dataviz/style.json?key=${process.env.MAPTILER_API_KEY}`
+    ? `https://api.maptiler.com/maps/streets/style.json?key=${process.env.MAPTILER_API_KEY}`
     : backupMapStyle;
   const mapStyleRoadLabelsLayer = process.env.MAPTILER_API_KEY
-    ? 'Road labels'
+    ? 'road_label'
     : 'roads_labels_major';
 
   // enable backup map tiles


### PR DESCRIPTION
Made a couple small improvements and clean-up changes to the map pages:

- Parking map: set bicycle network to appear underneath road labels for the parking map so that road labels remain visible
- Parking and LTS maps: Ensure that the correct road labels layer name is used depending on whether the base layers are from maptiler or fallback base map style
- Parking map: previously, the "select on map" button in a parking feature description would not center the feature on the map and would become disabled when the feature was selected. Now the button centers the feature on the map and changes to "center on map" when the feature is already selected.
- Submission dashboard: prevent long words (e.g. URLs) in comment text from breaking layout