### PR TITLE
Improve e2e CI job runtime with Playwright browser caching

### DIFF
--- a/.github/workflows/test-preview.yml
+++ b/.github/workflows/test-preview.yml
@@ -20,7 +20,7 @@ jobs:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgres:16
+        image: postgres:15
         # Provide the password for postgres
         env:
           POSTGRES_PASSWORD: postgres
@@ -59,7 +59,7 @@ jobs:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgres:16
+        image: postgres:15
         # Provide the password for postgres
         env:
           POSTGRES_PASSWORD: postgres
@@ -112,7 +112,7 @@ jobs:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgres:16
+        image: postgres:15
         # Provide the password for postgres
         env:
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/test-preview.yml
+++ b/.github/workflows/test-preview.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: bikespace_frontend/package-lock.json
       - name: Check code style
@@ -130,7 +130,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: bikespace_frontend/package-lock.json
       - name: Install frontend dependencies
@@ -177,7 +177,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: bikespace_frontend/package-lock.json
       - name: Build static frontend

--- a/.github/workflows/test-preview.yml
+++ b/.github/workflows/test-preview.yml
@@ -1,7 +1,7 @@
 name: Test and Preview
 on:
   pull_request:
-    types: [opened, synchronize, edited, ready_for_review]
+    types: [opened, synchronize, ready_for_review]
     paths:
       - bikespace_api/**
       - bikespace_frontend/**

--- a/.github/workflows/test-preview.yml
+++ b/.github/workflows/test-preview.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - bikespace_api/**
       - bikespace_frontend/**
+      - .github/workflows/test-preview.yml
 jobs:
   apitest:
     name: API tests

--- a/.github/workflows/test-preview.yml
+++ b/.github/workflows/test-preview.yml
@@ -19,7 +19,7 @@ jobs:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgres
+        image: postgres:16
         # Provide the password for postgres
         env:
           POSTGRES_PASSWORD: postgres
@@ -58,7 +58,7 @@ jobs:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgres
+        image: postgres:16
         # Provide the password for postgres
         env:
           POSTGRES_PASSWORD: postgres
@@ -90,7 +90,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: bikespace_frontend/package-lock.json
       - name: Check code style
@@ -111,7 +111,7 @@ jobs:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgres
+        image: postgres:16
         # Provide the password for postgres
         env:
           POSTGRES_PASSWORD: postgres
@@ -129,11 +129,29 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: bikespace_frontend/package-lock.json
+      - name: Install frontend dependencies
+        run: cd bikespace_frontend && npm install
+      - name: Get Playwright version
+        id: playwright-version
+        run: |
+          echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./bikespace_frontend/node_modules/@playwright/test/package.json').version)")" >> $GITHUB_ENV
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+      - name: Install Playwright browsers and system dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: cd bikespace_frontend && npx playwright install --with-deps
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: cd bikespace_frontend && npx playwright install-deps
       - name: Run end to end tests
-        run: make test-e2e
+        run: cd bikespace_frontend && npx playwright test
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
@@ -158,7 +176,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: bikespace_frontend/package-lock.json
       - name: Build static frontend


### PR DESCRIPTION
## Summary

- Cache Playwright browser binaries (keyed on `@playwright/test` version) so the ~300–500 MB download is skipped on repeat runs against the same PR
- OS system libraries (`install-deps`) still run on every job since the runner is ephemeral and they're not cached
- Pin Node.js to `24` (active LTS, supported through April 2028) across all frontend jobs; was `lts/*` which can break silently on LTS transitions
- Pin Postgres service image to `postgres:15` to match production; was untagged `latest`
- Remove `edited` from the workflow trigger types — PR description/title edits don't change code and shouldn't re-run CI
- Add `.github/workflows/test-preview.yml` to the workflow's path filter so changes to the workflow itself trigger a run

## Test plan

- [x] Confirm `test-e2e` passes on first run (cache miss — full browser install)
- [x] Confirm `test-e2e` passes on a second run against this PR (cache hit — browser install step skipped)
- [x] Confirm `test-frontend` and `publish` jobs pass with Node 24
- [x] Confirm playwright-report artifact is still uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)