### PR TITLE
Paginate the submissions feed

### DIFF
--- a/bikespace_frontend/src/components/dashboard/sidebar-content/_SidebarContent.module.scss
+++ b/bikespace_frontend/src/components/dashboard/sidebar-content/_SidebarContent.module.scss
@@ -81,3 +81,9 @@ h2.cardHeading {
   justify-content: center;
   margin: 1rem;
 }
+
+.loadMore {
+  display: flex;
+  justify-content: center;
+  padding: 12px;
+}

--- a/bikespace_frontend/src/components/dashboard/sidebar-content/_SidebarContentFeed.tsx
+++ b/bikespace_frontend/src/components/dashboard/sidebar-content/_SidebarContentFeed.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 
 import {useStore} from '@/states/store';
 import {useSubmissionsQuery} from '@/hooks';
@@ -6,6 +6,7 @@ import {useIsMobile} from '@/hooks/use-is-mobile';
 
 import {trackUmamiEvent} from '@/utils';
 
+import {SidebarButton} from '@/components/shared-ui/sidebar-button';
 import {Spinner} from '@/components/shared-ui/spinner';
 
 import {FeedSubmissionItem} from '../feed-submission-item';
@@ -13,6 +14,8 @@ import {FeedSubmissionItem} from '../feed-submission-item';
 import styles from './_SidebarContent.module.scss';
 
 type ItemRef = Record<number, HTMLButtonElement>;
+
+export const FEED_PAGE_SIZE = 50;
 
 export function SidebarContentFeed() {
   const {submissions, selectedSubmission, setSelectedSubmission} = useStore(
@@ -26,6 +29,30 @@ export function SidebarContentFeed() {
   const isMobile = useIsMobile();
 
   const itemRefs = useRef<ItemRef>({});
+  const [visibleCount, setVisibleCount] = useState(FEED_PAGE_SIZE);
+  const newestSubmissions = useMemo(
+    () => [...submissions].reverse(),
+    [submissions]
+  );
+  const visibleSubmissions = newestSubmissions.slice(0, visibleCount);
+  const hasMoreSubmissions = visibleCount < newestSubmissions.length;
+
+  useEffect(() => {
+    setVisibleCount(FEED_PAGE_SIZE);
+  }, [submissions]);
+
+  useEffect(() => {
+    if (!selectedSubmission) return;
+
+    const selectedIndex = newestSubmissions.findIndex(
+      submission => submission.id === selectedSubmission
+    );
+    if (selectedIndex < 0) return;
+
+    const requiredCount =
+      Math.ceil((selectedIndex + 1) / FEED_PAGE_SIZE) * FEED_PAGE_SIZE;
+    setVisibleCount(currentCount => Math.max(currentCount, requiredCount));
+  }, [selectedSubmission, newestSubmissions]);
 
   // scroll selected item into view when:
   // - focus changes
@@ -35,7 +62,7 @@ export function SidebarContentFeed() {
     if (!selectedSubmission) return;
 
     itemRefs.current[selectedSubmission]?.scrollIntoView();
-  }, [selectedSubmission, submissions, isMobile]);
+  }, [selectedSubmission, submissions, isMobile, visibleCount]);
 
   return (
     <>
@@ -46,7 +73,7 @@ export function SidebarContentFeed() {
         className={`${styles.ContentCard} ${styles.scrollableCard}`}
         data-testid="submissions-feed"
       >
-        {[...submissions].reverse().map(submission => (
+        {visibleSubmissions.map(submission => (
           <FeedSubmissionItem
             key={submission.id}
             submission={submission}
@@ -62,6 +89,16 @@ export function SidebarContentFeed() {
             }}
           />
         ))}
+        {hasMoreSubmissions ? (
+          <div className={styles.loadMore}>
+            <SidebarButton
+              type="button"
+              onClick={() => setVisibleCount(count => count + FEED_PAGE_SIZE)}
+            >
+              Load more submissions
+            </SidebarButton>
+          </div>
+        ) : null}
         <div className={styles.loadingIndicator}>
           {isLoading ? <Spinner label="Loading submissions..." /> : null}
         </div>

--- a/bikespace_frontend/src/components/dashboard/sidebar-content/sidebar-content-feed.test.tsx
+++ b/bikespace_frontend/src/components/dashboard/sidebar-content/sidebar-content-feed.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {
+  IssueType,
+  ParkingDuration,
+  SubmissionApiPayload,
+} from '@/interfaces/Submission';
+import {useStore} from '@/states/store';
+
+import {FEED_PAGE_SIZE, SidebarContentFeed} from './_SidebarContentFeed';
+
+jest.mock('@/hooks', () => ({
+  useSubmissionsQuery: () => ({isLoading: false}),
+}));
+
+jest.mock('@/hooks/use-is-mobile', () => ({
+  useIsMobile: () => false,
+}));
+
+jest.mock('../feed-submission-item', () => {
+  const React = jest.requireActual('react');
+
+  return {
+    FeedSubmissionItem: React.forwardRef(
+      (
+        {
+          submission,
+          onClick,
+        }: {
+          submission: SubmissionApiPayload;
+          onClick: React.MouseEventHandler<HTMLButtonElement>;
+        },
+        ref: React.ForwardedRef<HTMLButtonElement>
+      ) => (
+        <button ref={ref} onClick={onClick}>
+          Submission {submission.id}
+        </button>
+      )
+    ),
+  };
+});
+
+const submissions: SubmissionApiPayload[] = Array.from(
+  {length: 120},
+  (_, index) => ({
+    id: index + 1,
+    latitude: 43.65,
+    longitude: -79.38,
+    issues: [IssueType.Damaged],
+    parking_time: '2025-01-01 12:00:00',
+    parking_duration: ParkingDuration.Minutes,
+    comments: '',
+    submitted_datetime: '2025-01-01T12:00:00+00:00',
+  })
+);
+
+describe('SidebarContentFeed', () => {
+  beforeAll(() => {
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+  });
+
+  beforeEach(() => {
+    useStore.getState().ui.submissions.setSelectedSubmission(null);
+    useStore.getState().setSubmissions(submissions);
+  });
+
+  test('renders only the newest page of submissions initially', () => {
+    render(<SidebarContentFeed />);
+
+    expect(screen.getAllByText(/Submission \d+/)).toHaveLength(FEED_PAGE_SIZE);
+    expect(screen.getByText('Submission 120')).toBeInTheDocument();
+    expect(screen.queryByText('Submission 70')).not.toBeInTheDocument();
+  });
+
+  test('loads the next page on demand', async () => {
+    const user = userEvent.setup();
+    render(<SidebarContentFeed />);
+
+    await user.click(
+      screen.getByRole('button', {name: 'Load more submissions'})
+    );
+
+    expect(screen.getAllByText(/Submission \d+/)).toHaveLength(
+      FEED_PAGE_SIZE * 2
+    );
+    expect(screen.getByText('Submission 70')).toBeInTheDocument();
+  });
+
+  test('expands the feed to reveal a selected older submission', () => {
+    useStore.getState().ui.submissions.setSelectedSubmission(60);
+
+    render(<SidebarContentFeed />);
+
+    expect(screen.getByText('Submission 60')).toBeInTheDocument();
+    expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- render only the 50 newest submissions in the feed initially
- add incremental 50-item loading without changing the full map and analytics dataset
- automatically expand and scroll when a selected or deep-linked submission is outside the current page
- add regression coverage for the initial cap, loading another page, and revealing an older selection

This addresses the feed-rendering bottleneck discussed in #266 while preserving the existing full submission query for the map and dashboard insights.

## Testing

- `npm test -- --runInBand` (18 suites, 52 tests)
- `npm run lint` (passes; existing unrelated warnings remain)
- `npm run build`
- `git diff --check`

## AI assistance

Implemented with assistance from OpenAI Codex. I reviewed the resulting diff and validated it with the project tests, lint, and production build listed above.