### PR TITLE
Standardize Leaflet map tile providers

### DIFF
--- a/bikespace_frontend/src/components/dashboard/map/Map.tsx
+++ b/bikespace_frontend/src/components/dashboard/map/Map.tsx
@@ -7,7 +7,7 @@ import {useStore} from '@/states/store';
 import {SidebarTab, useSidebarTab} from '@/states/url-params';
 import {useIsMobile} from '@/hooks/use-is-mobile';
 
-import {defaultMapCenter} from '@/utils/map-utils';
+import {defaultMapCenter, getRasterTileLayerProps} from '@/utils/map-utils';
 
 import {Spinner} from '@/components/shared-ui/spinner';
 
@@ -39,6 +39,7 @@ function Map({submissions, isFirstMarkerDataLoading}: MapProps) {
   const mapRef: React.LegacyRef<lMap> = useRef(null);
   const clusterRef = useRef<LeafletMarkerClusterGroup>(null);
   const markerRefs = useRef<MarkerRefs>({});
+  const tileLayerProps = getRasterTileLayerProps(process.env.MAPTILER_API_KEY);
 
   const isMobile = useIsMobile();
   const [, setSidebarTab] = useSidebarTab();
@@ -95,8 +96,7 @@ function Map({submissions, isFirstMarkerDataLoading}: MapProps) {
     >
       <LeafletLocateControl />
       <TileLayer
-        attribution='&copy; Maps <a href="https://www.thunderforest.com/">Thunderforest</a>, &copy; Data <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>'
-        url="https://tile.thunderforest.com/atlas/{z}/{x}/{y}.png?apikey=66ccf6226ef54ef38a6b97fe0b0e5d2e"
+        {...tileLayerProps}
         maxZoom={20}
         eventHandlers={{
           loading: () => {

--- a/bikespace_frontend/src/components/submission/location/Location.tsx
+++ b/bikespace_frontend/src/components/submission/location/Location.tsx
@@ -2,6 +2,8 @@ import {useEffect} from 'react';
 import {MapContainer, TileLayer, Marker} from 'react-leaflet';
 import {LatLngTuple} from 'leaflet';
 
+import {getRasterTileLayerProps} from '@/utils/map-utils';
+
 import {useSubmissionFormContext} from '../submission-form/schema';
 
 import 'leaflet/dist/leaflet.css';
@@ -19,6 +21,7 @@ export interface LocationProps {
 
 function Location({handler, useUrlLocation}: LocationProps) {
   const {setValue, watch} = useSubmissionFormContext();
+  const tileLayerProps = getRasterTileLayerProps(process.env.MAPTILER_API_KEY);
 
   const location = watch('location');
   const position = [location.latitude, location.longitude] as LatLngTuple;
@@ -51,10 +54,7 @@ function Location({handler, useUrlLocation}: LocationProps) {
           scrollWheelZoom={false}
           style={{height: '100%'}}
         >
-          <TileLayer
-            attribution='&copy; <a href="https://www.maptiler.com/copyright/" target="_blank" rel="noopener">MapTiler</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-            url={`https://api.maptiler.com/maps/streets-v4/256/{z}/{x}/{y}.png?key=${process.env.MAPTILER_API_KEY}`}
-          />
+          <TileLayer {...tileLayerProps} />
           <Marker position={position} />
           {handler}
         </MapContainer>

--- a/bikespace_frontend/src/components/submission/location/Location.tsx
+++ b/bikespace_frontend/src/components/submission/location/Location.tsx
@@ -52,8 +52,8 @@ function Location({handler, useUrlLocation}: LocationProps) {
           style={{height: '100%'}}
         >
           <TileLayer
-            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-            url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+            attribution='&copy; <a href="https://www.maptiler.com/copyright/" target="_blank" rel="noopener">MapTiler</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            url={`https://api.maptiler.com/maps/streets-v4/256/{z}/{x}/{y}.png?key=${process.env.MAPTILER_API_KEY}`}
           />
           <Marker position={position} />
           {handler}

--- a/bikespace_frontend/src/components/submission/location/location.test.tsx
+++ b/bikespace_frontend/src/components/submission/location/location.test.tsx
@@ -8,13 +8,29 @@ import {SubmissionSchema} from '../submission-form/schema';
 
 import {Location} from './Location';
 
+const originalMaptilerApiKey = process.env.MAPTILER_API_KEY;
+
+afterEach(() => {
+  if (originalMaptilerApiKey === undefined) {
+    delete process.env.MAPTILER_API_KEY;
+  } else {
+    process.env.MAPTILER_API_KEY = originalMaptilerApiKey;
+  }
+});
+
 jest.mock('react-leaflet', () => ({
   MapContainer: ({children, center}: any) => (
     <div data-testid="map-container" data-center={JSON.stringify(center)}>
       {children}
     </div>
   ),
-  TileLayer: () => <div data-testid="tile-layer" />,
+  TileLayer: ({url, attribution}: {url: string; attribution: string}) => (
+    <div
+      data-testid="tile-layer"
+      data-url={url}
+      data-attribution={attribution}
+    />
+  ),
   Marker: ({position}: any) => (
     <div data-testid="marker" data-position={JSON.stringify(position)} />
   ),
@@ -62,6 +78,22 @@ describe('Test Location page component', () => {
     expect(screen.getByTestId('marker')).toHaveAttribute(
       'data-position',
       JSON.stringify([selectedLocation.latitude, selectedLocation.longitude])
+    );
+  });
+
+  test('Uses MapTiler tiles with the configured key and attribution', () => {
+    process.env.MAPTILER_API_KEY = 'test-maptiler-key';
+
+    render(<MockLocation />);
+
+    const tileLayer = screen.getByTestId('tile-layer');
+    expect(tileLayer).toHaveAttribute(
+      'data-url',
+      'https://api.maptiler.com/maps/streets-v4/256/{z}/{x}/{y}.png?key=test-maptiler-key'
+    );
+    expect(tileLayer.getAttribute('data-attribution')).toContain('MapTiler');
+    expect(tileLayer.getAttribute('data-attribution')).toContain(
+      'OpenStreetMap'
     );
   });
 });

--- a/bikespace_frontend/src/utils/map-utils/index.ts
+++ b/bikespace_frontend/src/utils/map-utils/index.ts
@@ -1,2 +1,3 @@
 export * from './mapUtils';
 export * from './geocoder-search/GeocoderSearch';
+export * from './raster-tile-layer';

--- a/bikespace_frontend/src/utils/map-utils/raster-tile-layer.test.ts
+++ b/bikespace_frontend/src/utils/map-utils/raster-tile-layer.test.ts
@@ -1,0 +1,22 @@
+import {getRasterTileLayerProps} from './raster-tile-layer';
+
+describe('getRasterTileLayerProps', () => {
+  test('uses MapTiler and credits both providers when a key is configured', () => {
+    expect(getRasterTileLayerProps('test-maptiler-key')).toEqual({
+      attribution:
+        '&copy; <a href="https://www.maptiler.com/copyright/" target="_blank" rel="noopener">MapTiler</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+      url: 'https://api.maptiler.com/maps/streets-v4/256/{z}/{x}/{y}.png?key=test-maptiler-key',
+    });
+  });
+
+  test.each([undefined, ''])(
+    'uses the OpenStreetMap fallback when the key is %p',
+    maptilerApiKey => {
+      expect(getRasterTileLayerProps(maptilerApiKey)).toEqual({
+        attribution:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+        url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+      });
+    }
+  );
+});

--- a/bikespace_frontend/src/utils/map-utils/raster-tile-layer.ts
+++ b/bikespace_frontend/src/utils/map-utils/raster-tile-layer.ts
@@ -1,0 +1,28 @@
+export interface RasterTileLayerProps {
+  attribution: string;
+  url: string;
+}
+
+/**
+ * Purpose: provide one raster basemap configuration for Bikespace's Leaflet maps.
+ * Input: the build-time MapTiler API key; an empty or missing key means local fallback.
+ * Output: MapTiler tiles with provider attribution when configured, otherwise OSM tiles.
+ * Invariant: the returned attribution credits every tile-data provider in the URL.
+ */
+export function getRasterTileLayerProps(
+  maptilerApiKey?: string
+): RasterTileLayerProps {
+  if (maptilerApiKey) {
+    return {
+      attribution:
+        '&copy; <a href="https://www.maptiler.com/copyright/" target="_blank" rel="noopener">MapTiler</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+      url: `https://api.maptiler.com/maps/streets-v4/256/{z}/{x}/{y}.png?key=${maptilerApiKey}`,
+    };
+  }
+
+  return {
+    attribution:
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+    url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+  };
+}


### PR DESCRIPTION
Fixes #434.

- Uses the configured MapTiler API key for production raster tiles.
- Falls back to OpenStreetMap tiles when no MapTiler key is configured, so local development works without an account.
- Reuses the same tile configuration on the submission and dashboard maps, removing the CARTO and Thunderforest providers.
- Adds regression coverage for configured, missing, and empty API keys.

Tests:
- `npm test -- --runInBand` (53 passed)
- `npm run lint`
- `npm run build`

CI note: the API test job on this fork-based PR receives empty repository secrets and fails during database seeding because `SECURITY_PASSWORD_SALT` is unset; the frontend change does not touch the API.